### PR TITLE
Substitute {placeholder} patterns in system message from env vars

### DIFF
--- a/skydiscover/context_builder/default/builder.py
+++ b/skydiscover/context_builder/default/builder.py
@@ -22,6 +22,8 @@ _format_previous_attempts, _format_other_context_programs, _format_current_progr
 """
 
 import logging
+import os
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -34,6 +36,45 @@ logger = logging.getLogger(__name__)
 
 _TEMPLATES_DIR = str(Path(__file__).parent / "templates")
 _TEXT_LANGUAGES = {"text", "prompt", "text/plain"}
+
+_KNOWN_TEMPLATE_VARS = {
+    "current_program", "metrics", "previous_attempts", "other_context_programs",
+    "improvement_areas", "language", "timeout_warning", "search_guidance",
+}
+
+_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+
+
+class _EnvFormatDict(dict):
+    def __missing__(self, key):
+        val = os.environ.get(key.upper())
+        if val is not None:
+            return val
+        return f"{{{key}}}"
+
+
+def _substitute_placeholders(system_msg: str) -> str:
+    """Substitute {placeholder} patterns in system message from env vars."""
+    if not system_msg or "{" not in system_msg:
+        return system_msg
+    try:
+        return system_msg.format_map(_EnvFormatDict())
+    except (ValueError, IndexError):
+        return system_msg
+
+
+def _warn_unsubstituted_placeholders(system_msg: str) -> None:
+    if not system_msg:
+        return
+    found = _PLACEHOLDER_RE.findall(system_msg)
+    suspicious = [name for name in found if name not in _KNOWN_TEMPLATE_VARS]
+    if suspicious:
+        logger.warning(
+            "Unsubstituted placeholder(s) in system message: %s. "
+            "Set env vars (e.g. PROBLEM_STATEMENT for {problem_statement}) "
+            "or replace with actual content.",
+            ", ".join(f"{{{s}}}" for s in suspicious),
+        )
 
 
 def _filter_other_metrics(metrics: dict) -> dict:
@@ -161,13 +202,22 @@ class DefaultContextBuilder(ContextBuilder):
             return "full_rewrite_prompt_opt_user_message"
         return "full_rewrite_user_message"
 
+    _system_message_validated = False
+
     def _get_system_message(self) -> str:
-        """Return system message from override, template, or raw config string."""
+        """Substitutes {placeholder} patterns from environment variables."""
         if self.system_template_override:
             return self.template_manager.get_template(self.system_template_override)
         system_msg = self.context_config.system_message
         if system_msg in self.template_manager.templates:
-            return self.template_manager.get_template(system_msg)
+            system_msg = self.template_manager.get_template(system_msg)
+
+        system_msg = _substitute_placeholders(system_msg)
+
+        if not DefaultContextBuilder._system_message_validated:
+            DefaultContextBuilder._system_message_validated = True
+            _warn_unsubstituted_placeholders(system_msg)
+
         return system_msg
 
     # ------------------------------------------------------------------

--- a/skydiscover/context_builder/default/builder.py
+++ b/skydiscover/context_builder/default/builder.py
@@ -38,8 +38,14 @@ _TEMPLATES_DIR = str(Path(__file__).parent / "templates")
 _TEXT_LANGUAGES = {"text", "prompt", "text/plain"}
 
 _KNOWN_TEMPLATE_VARS = {
-    "current_program", "metrics", "previous_attempts", "other_context_programs",
-    "improvement_areas", "language", "timeout_warning", "search_guidance",
+    "current_program",
+    "metrics",
+    "previous_attempts",
+    "other_context_programs",
+    "improvement_areas",
+    "language",
+    "timeout_warning",
+    "search_guidance",
 }
 
 _PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
@@ -91,6 +97,7 @@ class DefaultContextBuilder(ContextBuilder):
         self.system_template_override = None
         self.user_template_override = None
         self.template_manager = TemplateManager(_TEMPLATES_DIR, self.context_config.template_dir)
+        self._system_message_warned = False
 
     def set_templates(
         self, system_template: Optional[str] = None, user_template: Optional[str] = None
@@ -202,10 +209,8 @@ class DefaultContextBuilder(ContextBuilder):
             return "full_rewrite_prompt_opt_user_message"
         return "full_rewrite_user_message"
 
-    _system_message_validated = False
-
     def _get_system_message(self) -> str:
-        """Substitutes {placeholder} patterns from environment variables."""
+        """Return system message, substituting {placeholder} patterns from env vars."""
         if self.system_template_override:
             return self.template_manager.get_template(self.system_template_override)
         system_msg = self.context_config.system_message
@@ -214,8 +219,8 @@ class DefaultContextBuilder(ContextBuilder):
 
         system_msg = _substitute_placeholders(system_msg)
 
-        if not DefaultContextBuilder._system_message_validated:
-            DefaultContextBuilder._system_message_validated = True
+        if not self._system_message_warned:
+            self._system_message_warned = True
             _warn_unsubstituted_placeholders(system_msg)
 
         return system_msg

--- a/tests/test_placeholder_substitution.py
+++ b/tests/test_placeholder_substitution.py
@@ -1,0 +1,77 @@
+"""Tests for placeholder substitution helpers in the default context builder."""
+
+import logging
+
+import pytest
+
+from skydiscover.context_builder.default.builder import (
+    _EnvFormatDict,
+    _KNOWN_TEMPLATE_VARS,
+    _substitute_placeholders,
+    _warn_unsubstituted_placeholders,
+)
+
+
+class TestSubstitutePlaceholders:
+    def test_resolves_env_var(self, monkeypatch):
+        monkeypatch.setenv("PROBLEM_STATEMENT", "Optimize the loss function")
+        result = _substitute_placeholders("Task: {problem_statement}")
+        assert result == "Task: Optimize the loss function"
+
+    def test_leaves_unknown_var_literal(self, monkeypatch):
+        monkeypatch.delenv("UNKNOWN_VAR", raising=False)
+        result = _substitute_placeholders("Value is {unknown_var}")
+        assert result == "Value is {unknown_var}"
+
+    def test_no_braces_returns_unchanged(self):
+        text = "No placeholders here."
+        assert _substitute_placeholders(text) is text
+
+    def test_empty_string_returns_unchanged(self):
+        assert _substitute_placeholders("") == ""
+
+    def test_none_returns_none(self):
+        assert _substitute_placeholders(None) is None
+
+    def test_mixed_resolved_and_unresolved(self, monkeypatch):
+        monkeypatch.setenv("FOO", "bar")
+        monkeypatch.delenv("BAZ", raising=False)
+        result = _substitute_placeholders("{foo} and {baz}")
+        assert result == "bar and {baz}"
+
+
+class TestWarnUnsubstitutedPlaceholders:
+    def test_warns_for_unknown_placeholder(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _warn_unsubstituted_placeholders("Hello {problem_statement}")
+        assert "Unsubstituted placeholder" in caplog.text
+        assert "{problem_statement}" in caplog.text
+
+    def test_no_warn_for_known_template_vars(self, caplog):
+        msg = " ".join(f"{{{v}}}" for v in _KNOWN_TEMPLATE_VARS)
+        with caplog.at_level(logging.WARNING):
+            _warn_unsubstituted_placeholders(msg)
+        assert caplog.text == ""
+
+    def test_no_warn_when_all_resolved(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _warn_unsubstituted_placeholders("No placeholders here")
+        assert caplog.text == ""
+
+    def test_no_warn_for_empty_input(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _warn_unsubstituted_placeholders("")
+            _warn_unsubstituted_placeholders(None)
+        assert caplog.text == ""
+
+
+class TestEnvFormatDict:
+    def test_returns_env_value_uppercased(self, monkeypatch):
+        monkeypatch.setenv("MY_KEY", "my_value")
+        d = _EnvFormatDict()
+        assert d["my_key"] == "my_value"
+
+    def test_returns_literal_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv("MISSING_KEY", raising=False)
+        d = _EnvFormatDict()
+        assert d["missing_key"] == "{missing_key}"

--- a/tests/test_placeholder_substitution.py
+++ b/tests/test_placeholder_substitution.py
@@ -2,11 +2,9 @@
 
 import logging
 
-import pytest
-
 from skydiscover.context_builder.default.builder import (
-    _EnvFormatDict,
     _KNOWN_TEMPLATE_VARS,
+    _EnvFormatDict,
     _substitute_placeholders,
     _warn_unsubstituted_placeholders,
 )


### PR DESCRIPTION
  **Problem**

  Bundled benchmark configs (e.g. benchmarks/frontier-cs-eval/config.yaml) use
  {problem_statement} and {problem_constraints} placeholders in
  prompt.system_message, but DefaultContextBuilder._get_system_message() returns the
   raw string without substitution. The literal text {problem_statement} gets sent
  to the LLM.

  This is distinct from the known template variables ({current_program}, {metrics},
  etc.) which are substituted in the user message via .format() — the system message
   has no equivalent mechanism.

  **Fix**

  - Add _substitute_placeholders() which resolves {name} patterns from the
  corresponding NAME environment variable (uppercase). Unresolved placeholders are
  left as-is.
  - Warn once per instance if unsubstituted placeholders remain after resolution.
  - Apply substitution in _get_system_message() after template lookup.

  Includes tests for substitution, warning, and fallback behavior.

  **Alternative considered**

  Instead of env-var-based substitution, placeholders could be resolved via explicit
   kwargs passed through build_prompt() (similar to how user message template vars
  work). This would be more explicit and avoid potential collisions with shell
  environment variables (e.g. {language} matching $LANGUAGE), but would require
  changes to the Runner and config schema to thread values through. The env var
  approach keeps the change contained to the context builder and matches how wrapper
   scripts already inject problem-specific content.