### PR TITLE
Fix checkpoint selection by ignoring invalid directory names

### DIFF
--- a/skydiscover/cli.py
+++ b/skydiscover/cli.py
@@ -268,24 +268,30 @@ def _configure_logging(level_name: Optional[str]) -> None:
 
 
 def _find_latest_checkpoint(checkpoint_dir: str) -> Optional[str]:
-    """Return the path of the most recent checkpoint, or None."""
+    """Return the path of the latest checkpoint directory named like ``checkpoint_<n>``."""
     if not os.path.isdir(checkpoint_dir):
         return None
 
-    def get_iteration_from_path(path: str) -> int:
+    def parse_iteration(path: str) -> Optional[int]:
         try:
             return int(path.rsplit("_", 1)[-1])
         except (ValueError, IndexError):
-            return 0
+            return None
 
-    dirs = [
-        os.path.join(checkpoint_dir, d)
-        for d in os.listdir(checkpoint_dir)
-        if os.path.isdir(os.path.join(checkpoint_dir, d))
-    ]
-    if not dirs:
+    candidates = []
+    for name in os.listdir(checkpoint_dir):
+        full_path = os.path.join(checkpoint_dir, name)
+        if not os.path.isdir(full_path):
+            continue
+        iteration = parse_iteration(name)
+        if iteration is None:
+            continue
+        candidates.append((iteration, full_path))
+
+    if not candidates:
         return None
-    return sorted(dirs, key=get_iteration_from_path)[-1]
+
+    return max(candidates, key=lambda item: item[0])[1]
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_checkpoint_discovery.py
+++ b/tests/test_cli_checkpoint_discovery.py
@@ -1,0 +1,43 @@
+"""Tests for checkpoint discovery helper in the CLI."""
+
+from pathlib import Path
+
+from skydiscover.cli import _find_latest_checkpoint
+
+
+def test_find_latest_checkpoint_returns_highest_iteration(tmp_path: Path):
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+
+    (checkpoint_dir / "checkpoint_2").mkdir()
+    (checkpoint_dir / "checkpoint_10").mkdir()
+    (checkpoint_dir / "checkpoint_1").mkdir()
+
+    latest = _find_latest_checkpoint(str(checkpoint_dir))
+
+    assert latest == str(checkpoint_dir / "checkpoint_10")
+
+
+def test_find_latest_checkpoint_ignores_non_numeric_dirs(tmp_path: Path):
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+
+    (checkpoint_dir / "latest").mkdir()
+    (checkpoint_dir / "checkpoint_old").mkdir()
+    (checkpoint_dir / "checkpoint_3").mkdir()
+
+    latest = _find_latest_checkpoint(str(checkpoint_dir))
+
+    assert latest == str(checkpoint_dir / "checkpoint_3")
+
+
+def test_find_latest_checkpoint_returns_none_without_valid_checkpoints(tmp_path: Path):
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+
+    (checkpoint_dir / "latest").mkdir()
+    (checkpoint_dir / "checkpoint_old").mkdir()
+
+    latest = _find_latest_checkpoint(str(checkpoint_dir))
+
+    assert latest is None


### PR DESCRIPTION
## What changed
- Updated `_find_latest_checkpoint()` in `skydiscover/cli.py` to only consider directories that follow `checkpoint_<n>` naming.
- Ignored non-numeric/non-checkpoint folders instead of treating them as iteration `0`.
- Added focused tests in `tests/test_cli_checkpoint_discovery.py` for:
  - selecting the highest checkpoint iteration,
  - ignoring non-numeric directory names,
  - returning `None` when no valid checkpoint directories exist.

## Why
- The previous implementation could return unrelated directories (for example `latest` or `checkpoint_old`) when sorting checkpoint folders.
- Restricting candidates to valid numeric checkpoint names makes resume behavior deterministic and safer.

## Testing
- ✅ `source .venv/bin/activate && pytest -q`
  - Result: `11 passed`
