### PR TITLE
Fix default top_p to avoid Anthropic/Bedrock parameter conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,25 @@ uv sync --extra math
 uv run skydiscover-run benchmarks/math/circle_packing/initial_program.py \
   benchmarks/math/circle_packing/evaluator.py \
   --config benchmarks/math/circle_packing/config.yaml \
+  --search evox \
+  --iterations 100
+
+uv run skydiscover-run benchmarks/math/circle_packing/initial_program.py \
+  benchmarks/math/circle_packing/evaluator.py \
+  --config benchmarks/math/circle_packing/config.yaml \
   --search adaevolve \
   --iterations 100
 
 # Or run on your own problem
+# algo can be "evox", "adaevolve", "openevolve", "gepa", "shinkaevolve"
 uv run skydiscover-run initial_program.py evaluator.py \
-  --search evox \
+  --search <algo> \
   --model gpt-5 \
   --iterations 100
 
 # initial_program is optional — omit it to let the LLM start from scratch
 uv run skydiscover-run evaluator.py \
-  --search evox \
+  --search <algo> \
   --model gpt-5 \
   --iterations 100
 ```

--- a/benchmarks/arc_benchmark/config.yaml
+++ b/benchmarks/arc_benchmark/config.yaml
@@ -17,7 +17,7 @@ llm:
       weight: 1.0
   api_base: "https://api.openai.com/v1"
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32768
   timeout: 3000
 

--- a/benchmarks/frontier-cs-eval/config.yaml
+++ b/benchmarks/frontier-cs-eval/config.yaml
@@ -11,7 +11,7 @@ llm:
       weight: 1.0
   api_base: https://api.openai.com/v1
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
   # To use Gemini: override with --model gemini-3-pro-preview

--- a/benchmarks/gpu_mode/grayscale/config.yaml
+++ b/benchmarks/gpu_mode/grayscale/config.yaml
@@ -10,7 +10,7 @@ llm:
       weight: 1.0
   api_base: https://api.openai.com/v1
   temperature: 1.0
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/benchmarks/gpu_mode/mla_decode/config.yaml
+++ b/benchmarks/gpu_mode/mla_decode/config.yaml
@@ -10,7 +10,7 @@ llm:
       weight: 1.0
   api_base: https://api.openai.com/v1
   temperature: 1.0
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/benchmarks/gpu_mode/trimul/config.yaml
+++ b/benchmarks/gpu_mode/trimul/config.yaml
@@ -10,7 +10,7 @@ llm:
       weight: 1.0
   api_base: https://api.openai.com/v1
   temperature: 1.0
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/benchmarks/gpu_mode/vecadd/config.yaml
+++ b/benchmarks/gpu_mode/vecadd/config.yaml
@@ -11,7 +11,7 @@ llm:
       weight: 1.0
   api_base: https://api.openai.com/v1
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/configs/adaevolve.yaml
+++ b/configs/adaevolve.yaml
@@ -28,7 +28,7 @@ llm:
       weight: 1.0
   api_base: "https://api.openai.com/v1"
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
   # To use Gemini: comment out models + api_base above, uncomment below

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -10,7 +10,7 @@ llm:
     - name: "gpt-5"
       weight: 1.0
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/configs/evox.yaml
+++ b/configs/evox.yaml
@@ -20,7 +20,7 @@ llm:
       weight: 1.0
   api_base: "https://api.openai.com/v1"
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
   # To use Gemini: comment out models + api_base above, uncomment below

--- a/configs/human_in_the_loop.yaml
+++ b/configs/human_in_the_loop.yaml
@@ -14,7 +14,7 @@ llm:
     - name: "gpt-5"
       weight: 1.0
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/configs/openevolve_native.yaml
+++ b/configs/openevolve_native.yaml
@@ -23,7 +23,7 @@ llm:
       weight: 1.0
   api_base: "https://api.openai.com/v1"
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
 

--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -157,7 +157,7 @@ class LLMConfig(LLMModelConfig):
     # Generation parameters
     system_message: Optional[str] = "system_message"
     temperature: Optional[float] = 0.7
-    top_p: Optional[float] = 0.95
+    top_p: Optional[float] = None
     max_tokens: int = 32000
 
     # Request parameters

--- a/skydiscover/extras/external/defaults/openevolve_default.yaml
+++ b/skydiscover/extras/external/defaults/openevolve_default.yaml
@@ -6,7 +6,7 @@ checkpoint_interval: 10
 
 llm:
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   # gpt-4o/gpt-4o-mini cap at 16384 output tokens; gpt-5 models support more.
   # 16384 is the safe ceiling that works across all current OpenAI models.
   max_tokens: 16384

--- a/skydiscover/search/evox/config/search.yaml
+++ b/skydiscover/search/evox/config/search.yaml
@@ -12,7 +12,7 @@ llm:
   api_base: "https://api.openai.com/v1"
   api_key: ${OPENAI_API_KEY}
   temperature: 0.7
-  top_p: 0.95
+  # top_p: 0.95  # omitted by default; some providers (e.g. Anthropic) reject both temperature and top_p
   max_tokens: 32000
   timeout: 600
   guide_models:

--- a/tests/test_optional_llm_params.py
+++ b/tests/test_optional_llm_params.py
@@ -11,7 +11,7 @@ class TestLLMConfigOptionalParams:
     def test_default_values(self):
         cfg = LLMConfig(name="test-model")
         assert cfg.temperature == 0.7
-        assert cfg.top_p == 0.95
+        assert cfg.top_p is None
 
     def test_top_p_none(self):
         cfg = LLMConfig(name="test-model", top_p=None)
@@ -21,7 +21,7 @@ class TestLLMConfigOptionalParams:
     def test_temperature_none(self):
         cfg = LLMConfig(name="test-model", temperature=None)
         assert cfg.temperature is None
-        assert cfg.top_p == 0.95
+        assert cfg.top_p is None
 
     def test_both_none(self):
         cfg = LLMConfig(name="test-model", temperature=None, top_p=None)


### PR DESCRIPTION
## Summary
- Default `top_p` changed from `0.95` to `None` in `LLMConfig`, so only `temperature` is sent by default. Anthropic/Bedrock models reject requests with both set simultaneously (fixes #15).
- Commented out `top_p` across all config templates and benchmark configs for consistency.
- Updated README quick start to show both `evox` and `adaevolve` examples.

Fixes #15

## Test plan
- [x] Tested with `gpt-5-mini` (OpenAI) — 2 iterations, no errors
- [x] Tested with `claude-sonnet-4` (Anthropic) — 2 iterations, no errors
- [x] All 11 unit tests pass