### PR TITLE
Feat: Support explicit switch_interval in EvoX config

### DIFF
--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -502,7 +502,9 @@ class SearchConfig:
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     num_context_programs: int = 4
     output_dir: Optional[str] = None
-    switch_interval: Optional[int] = None  # EvoX: stagnation iters before strategy switch. Auto-calculated if None.
+    switch_interval: Optional[int] = (
+        None  # EvoX: stagnation iters before strategy switch. Auto-calculated if None.
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/skydiscover/search/evox/controller.py
+++ b/skydiscover/search/evox/controller.py
@@ -75,7 +75,7 @@ class CoEvolutionController(DiscoveryController):
         self._best_search_score: Optional[float] = None
         self._num_search_evolutions = 0
 
-        self._switch_interval = getattr(self.config.search, 'switch_interval', None)
+        self._switch_interval = getattr(self.config.search, "switch_interval", None)
         self._stagnant_count = 0
         self._last_tracked_best_score: Optional[float] = None
 
@@ -107,9 +107,13 @@ class CoEvolutionController(DiscoveryController):
 
         if self._switch_interval is None:
             self._switch_interval = max(1, int(max_iterations * self.DEFAULT_SWITCH_RATIO))
-            logger.info(f"Switch if {self._switch_interval} iterations of stagnation detected (auto: {max_iterations} * {self.DEFAULT_SWITCH_RATIO})")
+            logger.info(
+                f"Switch if {self._switch_interval} iterations of stagnation detected (auto: {max_iterations} * {self.DEFAULT_SWITCH_RATIO})"
+            )
         else:
-            logger.info(f"Switch if {self._switch_interval} iterations of stagnation detected (explicit config)")
+            logger.info(
+                f"Switch if {self._switch_interval} iterations of stagnation detected (explicit config)"
+            )
 
         self.start_db_stats = self.database.get_statistics(
             improvement_threshold=self.DEFAULT_IMPROVEMENT_THRESHOLD

--- a/tests/test_evox_switch_interval.py
+++ b/tests/test_evox_switch_interval.py
@@ -1,0 +1,30 @@
+"""Tests for explicit switch_interval in EvoX config."""
+
+from skydiscover.config import Config, SearchConfig
+
+
+class TestSwitchIntervalConfig:
+    def test_switch_interval_default_none(self):
+        config = SearchConfig()
+        assert config.switch_interval is None
+
+    def test_switch_interval_from_yaml_dict(self):
+        config = Config.from_dict(
+            {
+                "search": {
+                    "type": "evox",
+                    "switch_interval": 5,
+                },
+            }
+        )
+        assert config.search.switch_interval == 5
+
+    def test_switch_interval_omitted_stays_none(self):
+        config = Config.from_dict(
+            {
+                "search": {
+                    "type": "evox",
+                },
+            }
+        )
+        assert config.search.switch_interval is None


### PR DESCRIPTION
**Problem**

  EvoX auto-calculates switch_interval as max(1, int(max_iterations * 0.10)). This
  breaks when running in batches with resume — e.g., running 10 iterations at a
  time gives switch_interval=1 (switch every iteration) instead of the intended
  value for the full run. There's no way to override this without patching code.

  **Fix**

  - Add optional switch_interval field to SearchConfig (defaults to None)
  - When set, EvoX uses the configured value directly
  - When None, auto-calculates as before (no behavior change for existing configs)
  - Log message distinguishes auto vs explicit: (auto: 100 * 0.1) or (explicit
  config)

  **Usage**

  search:
    type: evox
    switch_interval: 5  # optional — omit for auto-calculation

**Notes**
  Includes tests for config parsing and default behavior.