### PR TITLE
Ci/test hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,40 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.10"
+          enable-cache: true
       - run: uv sync --frozen --extra dev
       - run: uv run black --check skydiscover/
       - run: uv run isort --check skydiscover/
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.10"
+          enable-cache: true
       - run: uv sync --frozen --extra dev
       - name: Smoke test — package imports cleanly
         run: uv run python -c "from skydiscover import Runner, run_discovery, discover_solution, __version__; print(f'skydiscover {__version__} OK')"
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.10"
+          enable-cache: true
+      - run: uv build

--- a/skydiscover/cli.py
+++ b/skydiscover/cli.py
@@ -221,9 +221,7 @@ async def main_async() -> int:
             if not os.path.exists(args.checkpoint):
                 print(f"Error: Checkpoint directory '{args.checkpoint}' not found", file=sys.stderr)
                 return 1
-            print(f"Loading checkpoint from {args.checkpoint}")
-            runner.database.load(args.checkpoint)
-            print(f"Checkpoint loaded (iteration {runner.database.last_iteration})")
+            print(f"Will resume from checkpoint: {args.checkpoint}")
 
         # Run the discovery
         best_program = await runner.run(

--- a/skydiscover/evaluation/container_evaluator.py
+++ b/skydiscover/evaluation/container_evaluator.py
@@ -105,6 +105,12 @@ class ContainerizedEvaluator:
             finally:
                 self.container_id = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def __del__(self):
         """Safety net: stop the container if close() was never called."""
         try:

--- a/skydiscover/evaluation/container_evaluator.py
+++ b/skydiscover/evaluation/container_evaluator.py
@@ -84,12 +84,32 @@ class ContainerizedEvaluator:
 
     def close(self):
         """Stop and remove the persistent container."""
-        if getattr(self, "container_id", None):
-            subprocess.run(
-                ["docker", "stop", self.container_id],
-                capture_output=True,
-            )
-            self.container_id = None
+        cid = getattr(self, "container_id", None)
+        if cid:
+            try:
+                logger.info(f"Stopping container {cid[:12]}...")
+                subprocess.run(
+                    ["docker", "stop", cid],
+                    capture_output=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired:
+                logger.warning(f"Timed out stopping container {cid[:12]}, killing...")
+                try:
+                    subprocess.run(["docker", "kill", cid], capture_output=True, timeout=10)
+                except Exception:
+                    logger.warning(f"Failed to kill container {cid[:12]}", exc_info=True)
+            except Exception:
+                logger.warning(f"Failed to stop container {cid[:12]}", exc_info=True)
+            finally:
+                self.container_id = None
+
+    def __del__(self):
+        """Safety net: stop the container if close() was never called."""
+        try:
+            self.close()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     # Public API — mirrors Evaluator's interface

--- a/skydiscover/evaluation/container_evaluator.py
+++ b/skydiscover/evaluation/container_evaluator.py
@@ -92,6 +92,7 @@ class ContainerizedEvaluator:
                     ["docker", "stop", cid],
                     capture_output=True,
                     timeout=30,
+                    check=True,
                 )
             except subprocess.TimeoutExpired:
                 logger.warning(f"Timed out stopping container {cid[:12]}, killing...")

--- a/skydiscover/evaluation/evaluator.py
+++ b/skydiscover/evaluation/evaluator.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import time
 import traceback
+import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 from skydiscover.config import EvaluatorConfig
@@ -58,12 +59,13 @@ class Evaluator:
         if eval_dir not in sys.path:
             sys.path.insert(0, eval_dir)
 
-        spec = importlib.util.spec_from_file_location("evaluation_module", self.evaluation_file)
+        self._module_name = f"_skydiscover_eval_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(self._module_name, self.evaluation_file)
         if spec is None or spec.loader is None:
             raise ImportError(f"Cannot load module from {self.evaluation_file}")
 
         module = importlib.util.module_from_spec(spec)
-        sys.modules["evaluation_module"] = module
+        sys.modules[self._module_name] = module
         spec.loader.exec_module(module)
 
         if not hasattr(module, "evaluate"):

--- a/skydiscover/evaluation/evaluator.py
+++ b/skydiscover/evaluation/evaluator.py
@@ -191,6 +191,10 @@ class Evaluator:
             args_list=list(programs),
         )
 
+    def close(self) -> None:
+        """Remove the dynamically loaded evaluation module from sys.modules."""
+        sys.modules.pop(getattr(self, "_module_name", None), None)
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------

--- a/skydiscover/llm/llm_pool.py
+++ b/skydiscover/llm/llm_pool.py
@@ -20,12 +20,8 @@ class LLMPool:
             raise ValueError("LLMPool requires at least one model config")
 
         self.models_cfg = models_cfg
-        self.models = [
-            model_cfg.init_client(model_cfg) if model_cfg.init_client else OpenAILLM(model_cfg)
-            for model_cfg in models_cfg
-        ]
 
-        # Weights of each model in the pool: normalized to sum to 1
+        # Validate weights before creating clients to fail fast on bad config.
         self.weights = [m.weight for m in models_cfg]
         if any(w < 0 for w in self.weights):
             raise ValueError("LLMPool model weights must be non-negative")
@@ -33,6 +29,11 @@ class LLMPool:
         if total <= 0:
             raise ValueError("LLMPool model weights must sum to a positive value")
         self.weights = [w / total for w in self.weights]
+
+        self.models = [
+            model_cfg.init_client(model_cfg) if model_cfg.init_client else OpenAILLM(model_cfg)
+            for model_cfg in models_cfg
+        ]
         self.random_state = random.Random()
 
         # Logging

--- a/skydiscover/llm/llm_pool.py
+++ b/skydiscover/llm/llm_pool.py
@@ -28,6 +28,8 @@ class LLMPool:
         # Weights of each model in the pool: normalized to sum to 1
         self.weights = [m.weight for m in models_cfg]
         total = sum(self.weights)
+        if total == 0:
+            raise ValueError("LLMPool model weights must not all be zero")
         self.weights = [w / total for w in self.weights]
         self.random_state = random.Random()
 

--- a/skydiscover/llm/llm_pool.py
+++ b/skydiscover/llm/llm_pool.py
@@ -27,9 +27,11 @@ class LLMPool:
 
         # Weights of each model in the pool: normalized to sum to 1
         self.weights = [m.weight for m in models_cfg]
+        if any(w < 0 for w in self.weights):
+            raise ValueError("LLMPool model weights must be non-negative")
         total = sum(self.weights)
-        if total == 0:
-            raise ValueError("LLMPool model weights must not all be zero")
+        if total <= 0:
+            raise ValueError("LLMPool model weights must sum to a positive value")
         self.weights = [w / total for w in self.weights]
         self.random_state = random.Random()
 

--- a/skydiscover/llm/openai.py
+++ b/skydiscover/llm/openai.py
@@ -155,8 +155,14 @@ class OpenAILLM(LLMInterface):
                 params["reasoning_effort"] = reasoning_effort
 
         retries = kwargs.get("retries", self.retries)
+        if retries is None:
+            retries = 0
         retry_delay = kwargs.get("retry_delay", self.retry_delay)
+        if retry_delay is None:
+            retry_delay = 2
         timeout = kwargs.get("timeout", self.timeout)
+        if timeout is None:
+            timeout = 300
 
         for attempt in range(retries + 1):
             try:
@@ -216,9 +222,15 @@ class OpenAILLM(LLMInterface):
         if self.max_tokens is not None:
             params["max_output_tokens"] = kwargs.get("max_tokens", self.max_tokens)
 
-        retries = kwargs.get("retries", self.retries) or 0
-        retry_delay = kwargs.get("retry_delay", self.retry_delay) or 2
-        timeout = kwargs.get("timeout", self.timeout) or 300
+        retries = kwargs.get("retries", self.retries)
+        if retries is None:
+            retries = 0
+        retry_delay = kwargs.get("retry_delay", self.retry_delay)
+        if retry_delay is None:
+            retry_delay = 2
+        timeout = kwargs.get("timeout", self.timeout)
+        if timeout is None:
+            timeout = 300
 
         for attempt in range(retries + 1):
             try:

--- a/skydiscover/llm/openai.py
+++ b/skydiscover/llm/openai.py
@@ -154,15 +154,7 @@ class OpenAILLM(LLMInterface):
             if reasoning_effort is not None:
                 params["reasoning_effort"] = reasoning_effort
 
-        retries = kwargs.get("retries", self.retries)
-        if retries is None:
-            retries = 0
-        retry_delay = kwargs.get("retry_delay", self.retry_delay)
-        if retry_delay is None:
-            retry_delay = 2
-        timeout = kwargs.get("timeout", self.timeout)
-        if timeout is None:
-            timeout = 300
+        retries, retry_delay, timeout = self._resolve_retry_options(**kwargs)
 
         for attempt in range(retries + 1):
             try:
@@ -186,6 +178,19 @@ class OpenAILLM(LLMInterface):
             None, lambda: self.client.chat.completions.create(**params)
         )
         return response.choices[0].message.content
+
+    def _resolve_retry_options(self, **kwargs) -> Tuple[int, int, int]:
+        """Resolve retry/timeout options from kwargs, falling back to instance defaults."""
+        retries = kwargs.get("retries", self.retries)
+        if retries is None:
+            retries = 0
+        retry_delay = kwargs.get("retry_delay", self.retry_delay)
+        if retry_delay is None:
+            retry_delay = 2
+        timeout = kwargs.get("timeout", self.timeout)
+        if timeout is None:
+            timeout = 300
+        return retries, retry_delay, timeout
 
     # ------------------------------------------------------------------
     # Image generation (OpenAI Responses API)
@@ -222,15 +227,7 @@ class OpenAILLM(LLMInterface):
         if self.max_tokens is not None:
             params["max_output_tokens"] = kwargs.get("max_tokens", self.max_tokens)
 
-        retries = kwargs.get("retries", self.retries)
-        if retries is None:
-            retries = 0
-        retry_delay = kwargs.get("retry_delay", self.retry_delay)
-        if retry_delay is None:
-            retry_delay = 2
-        timeout = kwargs.get("timeout", self.timeout)
-        if timeout is None:
-            timeout = 300
+        retries, retry_delay, timeout = self._resolve_retry_options(**kwargs)
 
         for attempt in range(retries + 1):
             try:

--- a/skydiscover/runner.py
+++ b/skydiscover/runner.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import signal
+import sys
 import time
 import uuid
 from typing import Optional
@@ -354,8 +355,13 @@ class Runner:
     def _install_signal_handlers(self) -> None:
         def on_signal(signum, frame):
             logger.info(f"Signal {signum} received, shutting down...")
-            self.discovery_controller.request_shutdown()
-            signal.signal(signal.SIGINT, lambda s, f: __import__("sys").exit(0))
+            if self.discovery_controller is not None:
+                self.discovery_controller.request_shutdown()
+
+            def force_exit(signum, frame):
+                sys.exit(128 + signum)
+
+            signal.signal(signal.SIGINT, force_exit)
 
         signal.signal(signal.SIGINT, on_signal)
         signal.signal(signal.SIGTERM, on_signal)

--- a/skydiscover/runner.py
+++ b/skydiscover/runner.py
@@ -361,7 +361,10 @@ class Runner:
             def force_exit(signum, frame):
                 sys.exit(128 + signum)
 
+            # After the first termination signal, ensure subsequent SIGINT/SIGTERM
+            # cause an immediate exit instead of re-running the soft handler.
             signal.signal(signal.SIGINT, force_exit)
+            signal.signal(signal.SIGTERM, force_exit)
 
         signal.signal(signal.SIGINT, on_signal)
         signal.signal(signal.SIGTERM, on_signal)

--- a/skydiscover/search/base_database.py
+++ b/skydiscover/search/base_database.py
@@ -210,6 +210,7 @@ class ProgramDatabase(ABC):
     def _is_better(self, program1: Program, program2: Program) -> bool:
         """Determine if program1 has better fitness than program2."""
         if not program1.metrics and not program2.metrics:
+            # No evidence either way — keep the current best.
             return False
         if program1.metrics and not program2.metrics:
             return True

--- a/skydiscover/search/base_database.py
+++ b/skydiscover/search/base_database.py
@@ -210,7 +210,7 @@ class ProgramDatabase(ABC):
     def _is_better(self, program1: Program, program2: Program) -> bool:
         """Determine if program1 has better fitness than program2."""
         if not program1.metrics and not program2.metrics:
-            return program1.timestamp > program2.timestamp
+            return False
         if program1.metrics and not program2.metrics:
             return True
         if not program1.metrics and program2.metrics:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -123,7 +123,7 @@ class TestSmokePipeline:
         # Assertions
         assert isinstance(result, DiscoveryResult)
         assert result.best_score >= 0.8  # mock LLM produces `def solve` → scored 0.8
-        assert result.best_solution  # non-empty string
+        assert "def solve" in result.best_solution
         assert os.path.isdir(output_dir)
 
 
@@ -136,6 +136,15 @@ class TestBugFixGuards:
         cfgs = [
             LLMModelConfig(name="m1", weight=0.0, api_key="k", api_base="http://x"),
             LLMModelConfig(name="m2", weight=0.0, api_key="k", api_base="http://x"),
+        ]
+        with pytest.raises(ValueError, match="weights"):
+            LLMPool(cfgs)
+
+    def test_llm_pool_raises_on_negative_weight(self):
+        """LLMPool must raise ValueError when any model weight is negative."""
+        cfgs = [
+            LLMModelConfig(name="m1", weight=-1.0, api_key="k", api_base="http://x"),
+            LLMModelConfig(name="m2", weight=2.0, api_key="k", api_base="http://x"),
         ]
         with pytest.raises(ValueError, match="weights"):
             LLMPool(cfgs)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,154 @@
+"""Smoke tests for the end-to-end discovery pipeline and unit guards for recent bug fixes."""
+
+import os
+import textwrap
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from skydiscover.api import DiscoveryResult, run_discovery
+from skydiscover.config import Config, LLMModelConfig
+from skydiscover.evaluation.evaluator import Evaluator, EvaluatorConfig
+from skydiscover.llm.base import LLMResponse
+from skydiscover.llm.llm_pool import LLMPool
+
+# ---------------------------------------------------------------------------
+# Inline evaluator source — scores programs with `def solve` higher
+# ---------------------------------------------------------------------------
+EVALUATOR_SOURCE = textwrap.dedent("""\
+    import ast
+
+    def evaluate(program_path: str) -> dict:
+        with open(program_path, "r") as f:
+            source = f.read()
+
+        score = 0.1  # baseline for any non-empty program
+        try:
+            tree = ast.parse(source)
+            # reward programs that define a `solve` function
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name == "solve":
+                    score = 0.8
+                    break
+        except SyntaxError:
+            score = 0.0
+
+        return {"combined_score": score}
+    """)
+
+# ---------------------------------------------------------------------------
+# Inline seed program — intentionally does NOT define `solve` so it scores low
+# ---------------------------------------------------------------------------
+SEED_SOURCE = textwrap.dedent("""\
+    def hello():
+        return "hi"
+    """)
+
+# ---------------------------------------------------------------------------
+# Mock LLM response — a full-rewrite code block containing `def solve`
+# ---------------------------------------------------------------------------
+MOCK_LLM_CODE = textwrap.dedent("""\
+    def solve(x):
+        return x ** 2 + 1
+    """)
+
+MOCK_RESPONSE_TEXT = f"```python\n{MOCK_LLM_CODE}```"
+
+
+# ---------------------------------------------------------------------------
+# FakeLLMPool — replaces the real LLMPool so no OpenAI client is created
+# ---------------------------------------------------------------------------
+class FakeLLMPool:
+    """Drop-in replacement for LLMPool that returns a canned response."""
+
+    def __init__(self, models_cfg: List[LLMModelConfig]):
+        # Intentionally do NOT create real clients.
+        self.models_cfg = models_cfg
+
+    async def generate(
+        self, system_message: str, messages: List[Dict[str, Any]], **kwargs
+    ) -> LLMResponse:
+        return LLMResponse(text=MOCK_RESPONSE_TEXT)
+
+    async def generate_all(
+        self, system_message: str, messages: List[Dict[str, Any]], **kwargs
+    ) -> List[LLMResponse]:
+        return [LLMResponse(text=MOCK_RESPONSE_TEXT)]
+
+
+# ===========================================================================
+# Smoke test: end-to-end pipeline with mocked LLM
+# ===========================================================================
+class TestSmokePipeline:
+    def test_run_discovery_returns_result(self, tmp_path):
+        """run_discovery completes 2 iterations and returns a valid DiscoveryResult."""
+
+        # Write evaluator and seed program to tmp_path
+        evaluator_file = tmp_path / "evaluator.py"
+        evaluator_file.write_text(EVALUATOR_SOURCE)
+
+        seed_file = tmp_path / "seed.py"
+        seed_file.write_text(SEED_SOURCE)
+
+        output_dir = str(tmp_path / "output")
+
+        config = Config.from_dict(
+            {
+                "max_iterations": 2,
+                "diff_based_generation": False,
+                "monitor": {"enabled": False},
+                "search": {"type": "topk"},
+                "evaluator": {"evaluation_file": str(evaluator_file)},
+                "llm": {
+                    "models": [
+                        {"name": "fake-model", "api_key": "fake", "api_base": "http://localhost:1"}
+                    ],
+                },
+            }
+        )
+
+        with patch(
+            "skydiscover.search.default_discovery_controller.LLMPool",
+            FakeLLMPool,
+        ):
+            result = run_discovery(
+                evaluator=str(evaluator_file),
+                initial_program=str(seed_file),
+                config=config,
+                output_dir=output_dir,
+                cleanup=False,
+            )
+
+        # Assertions
+        assert isinstance(result, DiscoveryResult)
+        assert result.best_score >= 0.8  # mock LLM produces `def solve` → scored 0.8
+        assert result.best_solution  # non-empty string
+        assert os.path.isdir(output_dir)
+
+
+# ===========================================================================
+# Unit guards for recent bug fixes
+# ===========================================================================
+class TestBugFixGuards:
+    def test_llm_pool_raises_on_zero_weights(self):
+        """LLMPool must raise ValueError when all model weights are zero."""
+        cfgs = [
+            LLMModelConfig(name="m1", weight=0.0, api_key="k", api_base="http://x"),
+            LLMModelConfig(name="m2", weight=0.0, api_key="k", api_base="http://x"),
+        ]
+        with pytest.raises(ValueError, match="weights must not all be zero"):
+            # Patch OpenAILLM so we never touch a real client
+            with patch("skydiscover.llm.llm_pool.OpenAILLM"):
+                LLMPool(cfgs)
+
+    def test_evaluator_unique_module_names(self, tmp_path):
+        """Two Evaluator instances for the same file must get distinct _module_name values."""
+        eval_file = tmp_path / "eval.py"
+        eval_file.write_text("def evaluate(program_path):\n    return {'combined_score': 1.0}\n")
+
+        cfg = EvaluatorConfig(evaluation_file=str(eval_file))
+        ev1 = Evaluator(config=cfg)
+        ev2 = Evaluator(config=cfg)
+
+        assert ev1._module_name != ev2._module_name

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -137,10 +137,8 @@ class TestBugFixGuards:
             LLMModelConfig(name="m1", weight=0.0, api_key="k", api_base="http://x"),
             LLMModelConfig(name="m2", weight=0.0, api_key="k", api_base="http://x"),
         ]
-        with pytest.raises(ValueError, match="weights must not all be zero"):
-            # Patch OpenAILLM so we never touch a real client
-            with patch("skydiscover.llm.llm_pool.OpenAILLM"):
-                LLMPool(cfgs)
+        with pytest.raises(ValueError, match="weights"):
+            LLMPool(cfgs)
 
     def test_evaluator_unique_module_names(self, tmp_path):
         """Two Evaluator instances for the same file must get distinct _module_name values."""


### PR DESCRIPTION
  - CI now runs pytest on every PR (not just an import check)
  - New build job verifies the wheel builds after lint+test pass
  - enable-cache and timeout-minutes on all CI jobs
  - End-to-end smoke test: run_discovery() with mocked LLM, real evaluator, 2 iterations
  - Bug-fix guard: LLMPool raises on zero weights
  - Bug-fix guard: Evaluator gets unique module names