### PR TITLE
fix(cli): allow evaluation-only invocation without dummy seed path

### DIFF
--- a/skydiscover/cli.py
+++ b/skydiscover/cli.py
@@ -44,16 +44,12 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "initial_program",
-        nargs="?",
-        default=None,
-        help="Path to the initial program file (can be optional)",
-    )
-    parser.add_argument(
-        "evaluation_file",
+        "paths",
+        nargs="+",
+        metavar="path",
         help=(
-            "Evaluator: path to a Python file (must define evaluate()) "
-            "or a benchmark directory containing Dockerfile + evaluate.sh"
+            "Positional paths: either '<evaluation_file>' or "
+            "'<initial_program> <evaluation_file>'"
         ),
     )
     parser.add_argument("--config", "-c", help="Path to configuration file (YAML)", default=None)
@@ -94,7 +90,18 @@ def parse_args() -> argparse.Namespace:
         help="Search algorithm to use",
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if len(args.paths) == 1:
+        args.initial_program = None
+        args.evaluation_file = args.paths[0]
+    elif len(args.paths) == 2:
+        args.initial_program, args.evaluation_file = args.paths
+    else:
+        parser.error("Expected either '<evaluation_file>' or '<initial_program> <evaluation_file>'")
+
+    delattr(args, "paths")
+    return args
 
 
 def main() -> int:
@@ -275,9 +282,9 @@ def _find_latest_checkpoint(checkpoint_dir: str) -> Optional[str]:
     if not os.path.isdir(checkpoint_dir):
         return None
 
-    def parse_iteration(path: str) -> Optional[int]:
+    def parse_iteration(name: str) -> Optional[int]:
         try:
-            return int(path.rsplit("_", 1)[-1])
+            return int(name.rsplit("_", 1)[-1])
         except (ValueError, IndexError):
             return None
 

--- a/tests/test_cli_positional_paths.py
+++ b/tests/test_cli_positional_paths.py
@@ -1,0 +1,34 @@
+"""Tests for CLI positional path parsing."""
+
+import sys
+
+import pytest
+
+from skydiscover.cli import parse_args
+
+
+def test_parse_args_single_path_uses_evaluation_file(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["skydiscover-run", "evaluate.py"])
+
+    args = parse_args()
+
+    assert args.initial_program is None
+    assert args.evaluation_file == "evaluate.py"
+
+
+def test_parse_args_two_paths_use_initial_and_evaluation(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["skydiscover-run", "seed.py", "evaluate.py"])
+
+    args = parse_args()
+
+    assert args.initial_program == "seed.py"
+    assert args.evaluation_file == "evaluate.py"
+
+
+def test_parse_args_rejects_more_than_two_paths(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["skydiscover-run", "a.py", "b.py", "c.py"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args()
+
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## What changed
- Reworked CLI positional parsing to accept either:
  - `skydiscover-run <evaluation_file>` (evaluation-only mode)
  - `skydiscover-run <initial_program> <evaluation_file>` (seeded mode)
- Replaced the ambiguous positional pair (`initial_program?` + required `evaluation_file`) with a single positional list and explicit normalization logic.
- Added targeted tests in `tests/test_cli_positional_paths.py` for:
  - single-path invocation
  - two-path invocation
  - rejection of invalid 3+ positional paths

## Why
- The previous argparse shape made the documented optional-initial-program workflow fail in normal usage: if users passed only one positional path, argparse bound it to `initial_program` and still required `evaluation_file`.
- This produced a confusing UX where an "optional" positional argument could not actually be omitted.

## Insight / Why this matters
- **Root cause:** optional positional arguments that appear before a required positional are not skippable in typical CLI syntax. Argparse greedily assigns the first positional token to the first positional argument.
- **Why easy to miss:** the parser declaration looked logically correct (`nargs='?'` for initial program + required evaluation file), but argparse semantics make this pattern brittle.
- **Tradeoff:** parsing now performs an explicit cardinality check (1 or 2 positional paths) instead of relying on implicit positional binding.
- **Impact:** users can reliably run evaluation-only workflows without dummy arguments or parser workarounds, reducing startup friction for benchmark/evaluator-centric runs.

## Testing
- ✅ `source .venv/bin/activate && pytest -q`
  - `14 passed in 0.59s`
