### PR TITLE
Fix cloudcast evaluator: remove dead import and fix transfer time

### DIFF
--- a/benchmarks/ADRS/cloudcast/evaluator/evaluator.py
+++ b/benchmarks/ADRS/cloudcast/evaluator/evaluator.py
@@ -11,7 +11,6 @@ sys.path.insert(0, parent_dir)
 from utils import *
 from simulator import *
 from broadcast import *
-from initial_program import search_algorithm
 import networkx as nx
 
 

--- a/benchmarks/ADRS/cloudcast/evaluator/simulator.py
+++ b/benchmarks/ADRS/cloudcast/evaluator/simulator.py
@@ -165,8 +165,10 @@ class BCSimulator:
         for dst in self.dsts:
             partition_time = float("-inf")
             for i in range(self.num_partitions):
-                for edge in self.paths[dst][str(i)]:
-                    edge_data = self.g[edge[0]][edge[1]]
+                path_edges = self.paths[dst][str(i)]
+                bottleneck = min(self.g[e[0]][e[1]]['flow'] for e in path_edges)
+                t = self.partition_data_vol / bottleneck if bottleneck > 0 else float('inf')
+                partition_time = max(partition_time, t)
             t_dict[dst] = partition_time
 
         max_t = max(t_dict.values())


### PR DESCRIPTION
## Changes

- **`evaluator.py`**: Remove unused `from initial_program import search_algorithm` import that caused import errors at evaluation time.
- **`simulator.py`**: Fix `__transfer_time` — the original loop iterated over path edges but never updated `partition_time`, leaving it as `-inf`. Now correctly computes bottleneck flow per path and derives transfer time as `partition_data_vol / bottleneck`, taking the max across all partitions per destination.