### PR TITLE
Fix eval failures leaking into the program database

### DIFF
--- a/skydiscover/search/adaevolve/controller.py
+++ b/skydiscover/search/adaevolve/controller.py
@@ -667,6 +667,27 @@ class AdaEvolveController(DiscoveryController):
         metrics = eval_result.metrics
         artifacts = eval_result.artifacts
 
+        # Check for eval failure (e.g., constraint violation, malformed solution)
+        if (
+            metrics.get("validity") in (0, -1)
+            or (
+                metrics.get("timeout") is True 
+                and metrics.get("validity") is None
+            )
+            or (
+                metrics.get("combined_score") == 0 
+                and (metrics.get("error") is not None 
+                     or "error" in (artifacts or {}))
+            )
+        ):
+            error_msg = (
+                (metrics.get("error") if isinstance(metrics.get("error"), str) else None)
+                or (artifacts or {}).get("error")
+                or metrics.get("error_message")
+                or "Evaluation failed"
+            )
+            return SerializableResult(error=f"Eval failure: {error_msg}", iteration=iteration)
+
         # Extract image_path from evaluator metrics (non-image mode fallback)
         if not image_path:
             image_path = (

--- a/skydiscover/search/adaevolve/controller.py
+++ b/skydiscover/search/adaevolve/controller.py
@@ -670,14 +670,10 @@ class AdaEvolveController(DiscoveryController):
         # Check for eval failure (e.g., constraint violation, malformed solution)
         if (
             metrics.get("validity") in (0, -1)
+            or (metrics.get("timeout") is True and metrics.get("validity") is None)
             or (
-                metrics.get("timeout") is True 
-                and metrics.get("validity") is None
-            )
-            or (
-                metrics.get("combined_score") == 0 
-                and (metrics.get("error") is not None 
-                     or "error" in (artifacts or {}))
+                metrics.get("combined_score") == 0
+                and (metrics.get("error") is not None or "error" in (artifacts or {}))
             )
         ):
             error_msg = (

--- a/skydiscover/search/default_discovery_controller.py
+++ b/skydiscover/search/default_discovery_controller.py
@@ -618,6 +618,7 @@ class DiscoveryController:
                         else None
                     )
 
+                child_artifacts = child_eval_result.artifacts or {}
                 if (
                     child_metrics.get("validity") in (0, -1)
                     or (
@@ -626,7 +627,8 @@ class DiscoveryController:
                     )
                     or (
                         child_metrics.get("combined_score") == 0
-                        and child_metrics.get("error") is not None
+                        and (child_metrics.get("error") is not None 
+                             or "error" in child_artifacts)
                     )
                 ):
                     error_msg = (
@@ -635,6 +637,7 @@ class DiscoveryController:
                             if isinstance(child_metrics.get("error"), str)
                             else None
                         )
+                        or child_artifacts.get("error")
                         or child_metrics.get("error_message")
                         or "Evaluation failed (validity=0)"
                     )

--- a/skydiscover/search/default_discovery_controller.py
+++ b/skydiscover/search/default_discovery_controller.py
@@ -627,8 +627,7 @@ class DiscoveryController:
                     )
                     or (
                         child_metrics.get("combined_score") == 0
-                        and (child_metrics.get("error") is not None 
-                             or "error" in child_artifacts)
+                        and (child_metrics.get("error") is not None or "error" in child_artifacts)
                     )
                 ):
                     error_msg = (


### PR DESCRIPTION
**Problem**

Two bugs cause solutions that parsed correctly but fail evaluation (e.g., solution violates constraints, or evaluator returns `{"combined_score": 0.0, "error": "..."}` without raising an exception) to silently enter the program archive.

**Bug 1: Wrapper / Controller mismatch**: This affects all scaffolds using `default_discovery_controller.py`. `evaluation/wrapper.py` separates the evaluator's return dict into numeric metrics and string artifacts. The "error" key is a string, so it ends up in artifacts. However, the failure check at `default_discovery_controller.py:621-631` only checks `metrics.get("error")`, which is always None. This allows the eval failure to pass the check and enter the database with `combined_score=0.0`.

**Bug 2: AdaEvolve missing failure detection**: `search/adaevolve/controller.py`'s `_execute_generation()` has no equivalent of the default controller's failure check. It correctly catches eval exceptions, but if the evaluator returns normally with bad metrics, the program enters the database unconditionally.

**Fix**

**Bug 1**: Extract `child_artifacts` from the eval result and add `or "error" in child_artifacts` to the failure check's third clause. Also check artifacts when extracting the error message.

**Bug 2:**: Add the same failure check in `_execute_generation()` after evaluation, before building the `Program` object.

**How to identify leaked entries in existing traces**

Programs with combined_score=0.0 but missing task-specific metric keys (e.g., no "c1" for ac1, no "radii_sum" for circle packing) are leaked eval failures.