### PR TITLE
Add Claude Code as a single-agent baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,24 @@ If no markers are present, the entire file is treated as mutatable.
 | 🧪&nbsp;**GEPA&nbsp;Native** | `--search gepa_native` | Pareto-efficient search with reflective prompting and LLM-mediated merge |
 | 🗺️&nbsp;**OpenEvolve&nbsp;Native** | `--search openevolve_native` | MAP-Elites + island-based evolutionary search |
 
+### Single-agent baseline
+
+| Algorithm | Flag | Description |
+|:---|:---|:---|
+| 🤖&nbsp;**Claude&nbsp;Code** | `--search claude_code` | Single-agent baseline: Claude Code CLI runs autonomously inside Docker, iterating on the solution directly |
+
+**Requirements:** Docker, `ANTHROPIC_API_KEY`. The runner image is built automatically on first use.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+skydiscover-run initial_program.py evaluator/ -c config.yaml -s claude_code -m claude-sonnet-4-6 -i 100
+```
+
+To reproduce all math benchmark results:
+```bash
+bash run_math_benchmarks.sh   # runs all 14 benchmarks in batches of 3
+```
+
 ### External backends
 
 Install with `uv sync --extra external`, then use the corresponding flag:

--- a/benchmarks/math/signal_processing/evaluator/requirements.txt
+++ b/benchmarks/math/signal_processing/evaluator/requirements.txt
@@ -1,4 +1,4 @@
 # Requirements for Real-Time Signal Processing Example
 numpy>=1.21.0
 scipy>=1.7.0
-pywt
+PyWavelets

--- a/run_math_benchmarks.sh
+++ b/run_math_benchmarks.sh
@@ -36,23 +36,23 @@ echo "Batch 1 done."
 # echo "Batch 3 done."
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 4 — minimizing / autocorr family
+# BATCH 4 — minimizing_max_min_dist
 # ─────────────────────────────────────────────────────────────────────────────
 
 # $CMD $BENCH/minimizing_max_min_dist/2/initial_program.py $BENCH/minimizing_max_min_dist/2/evaluator -c $BENCH/minimizing_max_min_dist/2/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_2 &
 # $CMD $BENCH/minimizing_max_min_dist/3/initial_program.py $BENCH/minimizing_max_min_dist/3/evaluator -c $BENCH/minimizing_max_min_dist/3/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_3 &
-# $CMD $BENCH/first_autocorr_ineq/initial_program.py       $BENCH/first_autocorr_ineq/evaluator       -c $BENCH/first_autocorr_ineq/config.yaml       -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/first_autocorr_ineq       &
-# $CMD $BENCH/second_autocorr_ineq/initial_program.py      $BENCH/second_autocorr_ineq/evaluator      -c $BENCH/second_autocorr_ineq/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/second_autocorr_ineq      &
 
 # wait
 # echo "Batch 4 done."
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 5 — erdos / third autocorr
+# BATCH 5 — autocorr family + erdos
 # ─────────────────────────────────────────────────────────────────────────────
 
-# $CMD $BENCH/third_autocorr_ineq/initial_program.py $BENCH/third_autocorr_ineq/evaluator -c $BENCH/third_autocorr_ineq/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/third_autocorr_ineq &
-# $CMD $BENCH/erdos_min_overlap/initial_program.py   $BENCH/erdos_min_overlap/evaluator   -c $BENCH/erdos_min_overlap/config.yaml   -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/erdos_min_overlap   &
+# $CMD $BENCH/first_autocorr_ineq/initial_program.py  $BENCH/first_autocorr_ineq/evaluator  -c $BENCH/first_autocorr_ineq/config.yaml  -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/first_autocorr_ineq  &
+# $CMD $BENCH/second_autocorr_ineq/initial_program.py $BENCH/second_autocorr_ineq/evaluator -c $BENCH/second_autocorr_ineq/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/second_autocorr_ineq &
+# $CMD $BENCH/third_autocorr_ineq/initial_program.py  $BENCH/third_autocorr_ineq/evaluator  -c $BENCH/third_autocorr_ineq/config.yaml  -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/third_autocorr_ineq  &
+# $CMD $BENCH/erdos_min_overlap/initial_program.py    $BENCH/erdos_min_overlap/evaluator    -c $BENCH/erdos_min_overlap/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/erdos_min_overlap    &
 
 # wait
 # echo "Batch 5 done."

--- a/run_math_benchmarks.sh
+++ b/run_math_benchmarks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run all math benchmarks with Claude Code (100 iterations each).
-# Jobs are organized in batches of 4. Uncomment the next batch once the current one finishes.
+# Uncomment the next batch once the current one finishes.
 # Run from repo root: bash run_math_benchmarks.sh
 # Monitor: tail -f outputs_claude/<benchmark>/progress.log
 
@@ -14,47 +14,63 @@ ITERS=100
 BENCH="benchmarks/math"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 1
+# BATCH 1 — signal_processing (verify end-to-end before launching more)
 # ─────────────────────────────────────────────────────────────────────────────
 
-$CMD $BENCH/signal_processing/initial_program.py   $BENCH/signal_processing/evaluator   -c $BENCH/signal_processing/config.yaml   -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/signal_processing   &
-$CMD $BENCH/circle_packing/initial_program.py      $BENCH/circle_packing/evaluator      -c $BENCH/circle_packing/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing      &
-$CMD $BENCH/circle_packing_rect/initial_program.py $BENCH/circle_packing_rect/evaluator -c $BENCH/circle_packing_rect/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing_rect &
+$CMD $BENCH/signal_processing/initial_program.py $BENCH/signal_processing/evaluator -c $BENCH/signal_processing/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/signal_processing &
 
 wait
 echo "Batch 1 done."
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 2
+# BATCH 2 — circle packing pair
 # ─────────────────────────────────────────────────────────────────────────────
 
-# $CMD $BENCH/heilbronn_triangle/initial_program.py     $BENCH/heilbronn_triangle/evaluator     -c $BENCH/heilbronn_triangle/config.yaml     -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_triangle     &
-# $CMD $BENCH/heilbronn_convex/13/initial_program.py    $BENCH/heilbronn_convex/13/evaluator    -c $BENCH/heilbronn_convex/13/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_convex_13    &
-# $CMD $BENCH/heilbronn_convex/14/initial_program.py    $BENCH/heilbronn_convex/14/evaluator    -c $BENCH/heilbronn_convex/14/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_convex_14    &
-# $CMD $BENCH/hexagon_packing/11/initial_program.py     $BENCH/hexagon_packing/11/evaluator     -c $BENCH/hexagon_packing/11/config.yaml     -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/hexagon_packing_11     &
+# $CMD $BENCH/circle_packing/initial_program.py      $BENCH/circle_packing/evaluator      -c $BENCH/circle_packing/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing      &
+# $CMD $BENCH/circle_packing_rect/initial_program.py $BENCH/circle_packing_rect/evaluator -c $BENCH/circle_packing_rect/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing_rect &
 
 # wait
 # echo "Batch 2 done."
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 3
+# BATCH 3 — heilbronn family
 # ─────────────────────────────────────────────────────────────────────────────
 
-# $CMD $BENCH/hexagon_packing/12/initial_program.py        $BENCH/hexagon_packing/12/evaluator        -c $BENCH/hexagon_packing/12/config.yaml        -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/hexagon_packing_12        &
-# $CMD $BENCH/minimizing_max_min_dist/2/initial_program.py $BENCH/minimizing_max_min_dist/2/evaluator -c $BENCH/minimizing_max_min_dist/2/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_2 &
-# $CMD $BENCH/minimizing_max_min_dist/3/initial_program.py $BENCH/minimizing_max_min_dist/3/evaluator -c $BENCH/minimizing_max_min_dist/3/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_3 &
-# $CMD $BENCH/first_autocorr_ineq/initial_program.py       $BENCH/first_autocorr_ineq/evaluator       -c $BENCH/first_autocorr_ineq/config.yaml       -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/first_autocorr_ineq       &
+# $CMD $BENCH/heilbronn_triangle/initial_program.py  $BENCH/heilbronn_triangle/evaluator  -c $BENCH/heilbronn_triangle/config.yaml  -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_triangle  &
+# $CMD $BENCH/heilbronn_convex/13/initial_program.py $BENCH/heilbronn_convex/13/evaluator -c $BENCH/heilbronn_convex/13/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_convex_13 &
+# $CMD $BENCH/heilbronn_convex/14/initial_program.py $BENCH/heilbronn_convex/14/evaluator -c $BENCH/heilbronn_convex/14/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_convex_14 &
 
 # wait
 # echo "Batch 3 done."
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 4
+# BATCH 4 — minimizing / autocorr family
 # ─────────────────────────────────────────────────────────────────────────────
 
-# $CMD $BENCH/second_autocorr_ineq/initial_program.py $BENCH/second_autocorr_ineq/evaluator -c $BENCH/second_autocorr_ineq/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/second_autocorr_ineq &
-# $CMD $BENCH/third_autocorr_ineq/initial_program.py  $BENCH/third_autocorr_ineq/evaluator  -c $BENCH/third_autocorr_ineq/config.yaml  -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/third_autocorr_ineq  &
-# $CMD $BENCH/erdos_min_overlap/initial_program.py    $BENCH/erdos_min_overlap/evaluator    -c $BENCH/erdos_min_overlap/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/erdos_min_overlap    &
+# $CMD $BENCH/minimizing_max_min_dist/2/initial_program.py $BENCH/minimizing_max_min_dist/2/evaluator -c $BENCH/minimizing_max_min_dist/2/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_2 &
+# $CMD $BENCH/minimizing_max_min_dist/3/initial_program.py $BENCH/minimizing_max_min_dist/3/evaluator -c $BENCH/minimizing_max_min_dist/3/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_3 &
+# $CMD $BENCH/first_autocorr_ineq/initial_program.py       $BENCH/first_autocorr_ineq/evaluator       -c $BENCH/first_autocorr_ineq/config.yaml       -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/first_autocorr_ineq       &
+# $CMD $BENCH/second_autocorr_ineq/initial_program.py      $BENCH/second_autocorr_ineq/evaluator      -c $BENCH/second_autocorr_ineq/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/second_autocorr_ineq      &
 
 # wait
 # echo "Batch 4 done."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BATCH 5 — erdos / third autocorr
+# ─────────────────────────────────────────────────────────────────────────────
+
+# $CMD $BENCH/third_autocorr_ineq/initial_program.py $BENCH/third_autocorr_ineq/evaluator -c $BENCH/third_autocorr_ineq/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/third_autocorr_ineq &
+# $CMD $BENCH/erdos_min_overlap/initial_program.py   $BENCH/erdos_min_overlap/evaluator   -c $BENCH/erdos_min_overlap/config.yaml   -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/erdos_min_overlap   &
+
+# wait
+# echo "Batch 5 done."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BATCH 6 — hexagon packing (last, most compute-heavy)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# $CMD $BENCH/hexagon_packing/11/initial_program.py $BENCH/hexagon_packing/11/evaluator -c $BENCH/hexagon_packing/11/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/hexagon_packing_11 &
+# $CMD $BENCH/hexagon_packing/12/initial_program.py $BENCH/hexagon_packing/12/evaluator -c $BENCH/hexagon_packing/12/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/hexagon_packing_12 &
+
+# wait
+# echo "Batch 6 done."

--- a/run_math_benchmarks.sh
+++ b/run_math_benchmarks.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Run all math benchmarks with Claude Code (100 iterations each).
+# Jobs are organized in batches of 4. Uncomment the next batch once the current one finishes.
+# Run from repo root: bash run_math_benchmarks.sh
+# Monitor: tail -f outputs_claude/<benchmark>/progress.log
+
+cd "$(dirname "$0")"
+
+OUTDIR="outputs_claude"
+CMD="skydiscover-run"
+SEARCH="claude_code"
+MODEL="claude-sonnet-4-6"
+ITERS=100
+BENCH="benchmarks/math"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BATCH 1
+# ─────────────────────────────────────────────────────────────────────────────
+
+$CMD $BENCH/signal_processing/initial_program.py   $BENCH/signal_processing/evaluator   -c $BENCH/signal_processing/config.yaml   -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/signal_processing   &
+$CMD $BENCH/circle_packing/initial_program.py      $BENCH/circle_packing/evaluator      -c $BENCH/circle_packing/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing      &
+$CMD $BENCH/circle_packing_rect/initial_program.py $BENCH/circle_packing_rect/evaluator -c $BENCH/circle_packing_rect/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing_rect &
+
+wait
+echo "Batch 1 done."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BATCH 2
+# ─────────────────────────────────────────────────────────────────────────────
+
+# $CMD $BENCH/heilbronn_triangle/initial_program.py     $BENCH/heilbronn_triangle/evaluator     -c $BENCH/heilbronn_triangle/config.yaml     -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_triangle     &
+# $CMD $BENCH/heilbronn_convex/13/initial_program.py    $BENCH/heilbronn_convex/13/evaluator    -c $BENCH/heilbronn_convex/13/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_convex_13    &
+# $CMD $BENCH/heilbronn_convex/14/initial_program.py    $BENCH/heilbronn_convex/14/evaluator    -c $BENCH/heilbronn_convex/14/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/heilbronn_convex_14    &
+# $CMD $BENCH/hexagon_packing/11/initial_program.py     $BENCH/hexagon_packing/11/evaluator     -c $BENCH/hexagon_packing/11/config.yaml     -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/hexagon_packing_11     &
+
+# wait
+# echo "Batch 2 done."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BATCH 3
+# ─────────────────────────────────────────────────────────────────────────────
+
+# $CMD $BENCH/hexagon_packing/12/initial_program.py        $BENCH/hexagon_packing/12/evaluator        -c $BENCH/hexagon_packing/12/config.yaml        -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/hexagon_packing_12        &
+# $CMD $BENCH/minimizing_max_min_dist/2/initial_program.py $BENCH/minimizing_max_min_dist/2/evaluator -c $BENCH/minimizing_max_min_dist/2/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_2 &
+# $CMD $BENCH/minimizing_max_min_dist/3/initial_program.py $BENCH/minimizing_max_min_dist/3/evaluator -c $BENCH/minimizing_max_min_dist/3/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/minimizing_max_min_dist_3 &
+# $CMD $BENCH/first_autocorr_ineq/initial_program.py       $BENCH/first_autocorr_ineq/evaluator       -c $BENCH/first_autocorr_ineq/config.yaml       -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/first_autocorr_ineq       &
+
+# wait
+# echo "Batch 3 done."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BATCH 4
+# ─────────────────────────────────────────────────────────────────────────────
+
+# $CMD $BENCH/second_autocorr_ineq/initial_program.py $BENCH/second_autocorr_ineq/evaluator -c $BENCH/second_autocorr_ineq/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/second_autocorr_ineq &
+# $CMD $BENCH/third_autocorr_ineq/initial_program.py  $BENCH/third_autocorr_ineq/evaluator  -c $BENCH/third_autocorr_ineq/config.yaml  -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/third_autocorr_ineq  &
+# $CMD $BENCH/erdos_min_overlap/initial_program.py    $BENCH/erdos_min_overlap/evaluator    -c $BENCH/erdos_min_overlap/config.yaml    -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/erdos_min_overlap    &
+
+# wait
+# echo "Batch 4 done."

--- a/run_math_benchmarks.sh
+++ b/run_math_benchmarks.sh
@@ -14,23 +14,15 @@ ITERS=100
 BENCH="benchmarks/math"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BATCH 1 — signal_processing (verify end-to-end before launching more)
+# BATCH 1 — circle packing + signal processing
 # ─────────────────────────────────────────────────────────────────────────────
 
-$CMD $BENCH/signal_processing/initial_program.py $BENCH/signal_processing/evaluator -c $BENCH/signal_processing/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/signal_processing &
+$CMD $BENCH/signal_processing/initial_program.py   $BENCH/signal_processing/evaluator   -c $BENCH/signal_processing/config.yaml   -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/signal_processing   &
+$CMD $BENCH/circle_packing/initial_program.py      $BENCH/circle_packing/evaluator      -c $BENCH/circle_packing/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing      &
+$CMD $BENCH/circle_packing_rect/initial_program.py $BENCH/circle_packing_rect/evaluator -c $BENCH/circle_packing_rect/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing_rect &
 
 wait
 echo "Batch 1 done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# BATCH 2 — circle packing pair
-# ─────────────────────────────────────────────────────────────────────────────
-
-# $CMD $BENCH/circle_packing/initial_program.py      $BENCH/circle_packing/evaluator      -c $BENCH/circle_packing/config.yaml      -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing      &
-# $CMD $BENCH/circle_packing_rect/initial_program.py $BENCH/circle_packing_rect/evaluator -c $BENCH/circle_packing_rect/config.yaml -s $SEARCH -m $MODEL -i $ITERS -o $OUTDIR/circle_packing_rect &
-
-# wait
-# echo "Batch 2 done."
 
 # ─────────────────────────────────────────────────────────────────────────────
 # BATCH 3 — heilbronn family

--- a/skydiscover/cli.py
+++ b/skydiscover/cli.py
@@ -34,6 +34,7 @@ _SEARCH_CHOICES = [
     "shinkaevolve",
     "gepa",
     "gepa_native",
+    "claude_code",
 ]
 
 

--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -462,6 +462,19 @@ class OpenEvolveNativeDatabaseConfig(DatabaseConfig):
 
 
 @dataclass
+class ClaudeCodeConfig(DatabaseConfig):
+    """Configuration for the Claude Code baseline.
+
+    Claude Code runs autonomously inside a Docker container, iterating on
+    the solution using the evaluator directly.  max_turns maps to the
+    --max-turns flag passed to the claude CLI.
+    """
+
+    max_turns: int = 50
+    docker_image: str = "skydiscover-claude-code:latest"
+
+
+@dataclass
 class GEPANativeDatabaseConfig(DatabaseConfig):
     """Configuration for GEPA Native search database.
 
@@ -491,6 +504,7 @@ _DB_CONFIG_BY_TYPE: Dict[str, type] = {
     "adaevolve": AdaEvolveDatabaseConfig,
     "openevolve_native": OpenEvolveNativeDatabaseConfig,
     "gepa_native": GEPANativeDatabaseConfig,
+    "claude_code": ClaudeCodeConfig,
 }
 
 

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -308,6 +308,7 @@ class ClaudeCodeController(DiscoveryController):
             def _run_with_turn_limit() -> None:
                 nonlocal cumulative_turns, total_cost_usd, stream_turns
                 start = time.monotonic()
+                hard_stop_at = 0.0  # monotonic time when hard stop was triggered
                 with open(log_path, "w") as log_file:
                     proc = subprocess.Popen(
                         cmd, stdout=subprocess.PIPE, stderr=log_file
@@ -320,60 +321,65 @@ class ClaudeCodeController(DiscoveryController):
                             try:
                                 evt = json.loads(raw_line)
                             except (json.JSONDecodeError, ValueError):
-                                continue
-                            evt_type = evt.get("type")
+                                pass
+                            else:
+                                evt_type = evt.get("type")
 
-                            if evt_type == "assistant":
-                                elapsed = time.monotonic() - start
-                                content = evt.get("message", {}).get("content", [])
-                                tool_names = [
-                                    c.get("name", "")
-                                    for c in content
-                                    if c.get("type") == "tool_use"
-                                ]
-                                if tool_names:
-                                    # Each assistant message with tool_use = one turn.
-                                    # Count these live so we have a hard stop even if
-                                    # --max-turns or the result event fails.
-                                    stream_turns += 1
-                                    _write_progress(
-                                        f"Active → {', '.join(tool_names)}"
-                                        f" (elapsed {elapsed:.0f}s,"
-                                        f" turn {stream_turns}/{max_turns})"
-                                    )
-                                    if stream_turns > max_turns:
-                                        # Hard stop fires at N+1 (not N) so that
-                                        # Claude Code's own --max-turns N fires first,
-                                        # emitting the result event with authoritative
-                                        # turn count and cost before we kill.
+                                if evt_type == "assistant":
+                                    elapsed = time.monotonic() - start
+                                    content = evt.get("message", {}).get("content", [])
+                                    tool_names = [
+                                        c.get("name", "")
+                                        for c in content
+                                        if c.get("type") == "tool_use"
+                                    ]
+                                    if tool_names:
+                                        # Each tool-use assistant message = one turn.
+                                        stream_turns += 1
                                         _write_progress(
-                                            f"Hard stop: stream turn count"
-                                            f" {stream_turns} exceeded {max_turns} — killing"
+                                            f"Active → {', '.join(tool_names)}"
+                                            f" (elapsed {elapsed:.0f}s,"
+                                            f" turn {stream_turns}/{max_turns})"
+                                        )
+                                        if stream_turns > max_turns and not hard_stop_at:
+                                            # Budget exceeded: don't SIGKILL immediately.
+                                            # Keep reading so the result event (with
+                                            # authoritative turn count and cost) can
+                                            # arrive before we kill.  Force-kill after
+                                            # 30 s if result never comes.
+                                            hard_stop_at = time.monotonic()
+                                            _write_progress(
+                                                f"Hard stop: stream turn {stream_turns}"
+                                                f" exceeded {max_turns} — waiting for result"
+                                            )
+
+                                elif evt_type == "result":
+                                    seg_turns = evt.get("num_turns", 0)
+                                    cumulative_turns += seg_turns
+                                    seg_cost = evt.get("total_cost_usd", 0) or 0
+                                    if seg_cost > total_cost_usd:
+                                        total_cost_usd = seg_cost
+                                    subtype = evt.get("subtype", "")
+                                    _write_progress(
+                                        f"Segment done ({subtype}): "
+                                        f"+{seg_turns} turns, "
+                                        f"{cumulative_turns}/{max_turns} cumulative, "
+                                        f"cost=${total_cost_usd:.4f}"
+                                    )
+                                    if cumulative_turns >= max_turns or hard_stop_at:
+                                        _write_progress(
+                                            f"Turn budget reached — stopping"
                                         )
                                         proc.kill()
                                         break
 
-                            elif evt_type == "result":
-                                # result fires once per claude -p segment; num_turns
-                                # is the authoritative turn count for that segment.
-                                seg_turns = evt.get("num_turns", 0)
-                                cumulative_turns += seg_turns
-                                seg_cost = evt.get("total_cost_usd", 0) or 0
-                                if seg_cost > total_cost_usd:
-                                    total_cost_usd = seg_cost
-                                subtype = evt.get("subtype", "")
+                            # Hard stop grace-period expired: force kill.
+                            if hard_stop_at and time.monotonic() - hard_stop_at > 30:
                                 _write_progress(
-                                    f"Segment done ({subtype}): "
-                                    f"+{seg_turns} turns, "
-                                    f"{cumulative_turns}/{max_turns} cumulative, "
-                                    f"cost=${total_cost_usd:.4f}"
+                                    f"Hard stop grace period elapsed — force killing"
                                 )
-                                if cumulative_turns >= max_turns:
-                                    _write_progress(
-                                        f"Turn budget ({max_turns}) exhausted — stopping"
-                                    )
-                                    proc.kill()
-                                    break
+                                proc.kill()
+                                break
 
                             # Wall-clock safety net.
                             elapsed = time.monotonic() - start

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -302,10 +302,11 @@ class ClaudeCodeController(DiscoveryController):
             # Shared state modified only from the executor thread.
             cumulative_turns = 0
             total_cost_usd = 0.0
+            stream_turns = 0  # live tool-use turn count; fallback when result never fires
             run_start = time.monotonic()
 
             def _run_with_turn_limit() -> None:
-                nonlocal cumulative_turns, total_cost_usd
+                nonlocal cumulative_turns, total_cost_usd, stream_turns
                 start = time.monotonic()
                 with open(log_path, "w") as log_file:
                     proc = subprocess.Popen(
@@ -316,33 +317,41 @@ class ClaudeCodeController(DiscoveryController):
                             log_file.write(raw_line.decode("utf-8", errors="replace"))
                             log_file.flush()
 
-                            # Parse stream-json events.  --max-turns is per-segment
-                            # (Claude resets the budget after context compaction), so
-                            # we track cumulative turns from result events across all
-                            # segments to enforce the GLOBAL budget.
                             try:
                                 evt = json.loads(raw_line)
                             except (json.JSONDecodeError, ValueError):
                                 continue
                             evt_type = evt.get("type")
 
-                            # Log tool calls so the user can follow along in
-                            # progress.log.  We don't use assistant events for turn
-                            # counting because a single logical turn may produce
-                            # multiple assistant messages (e.g. thinking + tool use).
                             if evt_type == "assistant":
                                 elapsed = time.monotonic() - start
+                                content = evt.get("message", {}).get("content", [])
                                 tool_names = [
                                     c.get("name", "")
-                                    for c in evt.get("message", {}).get("content", [])
+                                    for c in content
                                     if c.get("type") == "tool_use"
                                 ]
                                 if tool_names:
+                                    # Each assistant message with tool_use = one turn.
+                                    # Count these live so we have a hard stop even if
+                                    # --max-turns or the result event fails.
+                                    stream_turns += 1
                                     _write_progress(
                                         f"Active → {', '.join(tool_names)}"
                                         f" (elapsed {elapsed:.0f}s,"
-                                        f" turns so far ~{cumulative_turns})"
+                                        f" turn {stream_turns}/{max_turns})"
                                     )
+                                    if stream_turns > max_turns:
+                                        # Hard stop fires at N+1 (not N) so that
+                                        # Claude Code's own --max-turns N fires first,
+                                        # emitting the result event with authoritative
+                                        # turn count and cost before we kill.
+                                        _write_progress(
+                                            f"Hard stop: stream turn count"
+                                            f" {stream_turns} exceeded {max_turns} — killing"
+                                        )
+                                        proc.kill()
+                                        break
 
                             elif evt_type == "result":
                                 # result fires once per claude -p segment; num_turns
@@ -426,7 +435,31 @@ class ClaudeCodeController(DiscoveryController):
 
             await run_future  # propagate exceptions
 
-            # Final evaluation.
+            # actual_turns: prefer authoritative count from result events; fall back
+            # to the live stream_turns count (used when process was hard-killed before
+            # result fired).
+            actual_turns = cumulative_turns if cumulative_turns > 0 else stream_turns
+
+            # cost: comes from result event; if process was hard-killed scan log for
+            # any result event that may have been written before death.
+            if total_cost_usd == 0.0:
+                try:
+                    for line in log_path.read_text(errors="replace").splitlines():
+                        try:
+                            evt = json.loads(line)
+                            if evt.get("type") == "result":
+                                c = evt.get("total_cost_usd", 0) or 0
+                                if c > total_cost_usd:
+                                    total_cost_usd = c
+                                if cumulative_turns == 0:
+                                    actual_turns = max(actual_turns, evt.get("num_turns", 0))
+                        except (json.JSONDecodeError, ValueError):
+                            pass
+                except OSError:
+                    pass
+
+            # Final evaluation: always re-evaluate the best solution on disk so the
+            # reported score is reproducible (re-running best_program.py gives same #).
             try:
                 final_code = solution_path.read_text()
             except OSError:
@@ -436,7 +469,7 @@ class ClaudeCodeController(DiscoveryController):
 
             program_id = str(uuid.uuid4())
             eval_result = await self.evaluator.evaluate_program(final_code, program_id)
-            final_iter = max(cumulative_turns, 1)
+            final_iter = max(actual_turns, 1)
 
             program = Program(
                 id=program_id,
@@ -448,7 +481,7 @@ class ClaudeCodeController(DiscoveryController):
                 other_context_ids=[],
                 metadata={
                     "claude_code_max_turns": max_turns,
-                    "actual_turns": cumulative_turns,
+                    "actual_turns": actual_turns,
                 },
                 artifacts=eval_result.artifacts,
             )
@@ -467,7 +500,7 @@ class ClaudeCodeController(DiscoveryController):
                 summary = {
                     "model": model,
                     "max_turns": max_turns,
-                    "actual_turns": cumulative_turns,
+                    "actual_turns": actual_turns,
                     "cost_usd": round(total_cost_usd, 4),
                     "wall_seconds": round(run_elapsed, 1),
                     "baseline_score": initial.metrics.get("combined_score") if initial and initial.metrics else None,
@@ -478,7 +511,7 @@ class ClaudeCodeController(DiscoveryController):
                     json.dumps(summary, indent=2, default=str) + "\n"
                 )
                 _write_progress(
-                    f"Run complete: turns={cumulative_turns}/{max_turns}, "
+                    f"Run complete: turns={actual_turns}/{max_turns}, "
                     f"cost=${total_cost_usd:.4f}, "
                     f"time={run_elapsed:.0f}s, "
                     f"score={eval_result.metrics.get('combined_score', '?')}"

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -385,6 +385,26 @@ class ClaudeCodeController(DiscoveryController):
                                 break
                     finally:
                         proc.wait()
+                        # Drain any bytes left in the stdout pipe after we broke
+                        # from the reading loop (e.g. the result event emitted by
+                        # Claude Code just as the hard stop fired).  Capturing it
+                        # here gives us authoritative turn count and cost.
+                        try:
+                            for remaining_line in proc.stdout:
+                                log_file.write(remaining_line.decode("utf-8", errors="replace"))
+                                log_file.flush()
+                                try:
+                                    evt = json.loads(remaining_line)
+                                    if evt.get("type") == "result":
+                                        seg_turns = evt.get("num_turns", 0)
+                                        cumulative_turns += seg_turns
+                                        seg_cost = evt.get("total_cost_usd", 0) or 0
+                                        if seg_cost > total_cost_usd:
+                                            total_cost_usd = seg_cost
+                                except (json.JSONDecodeError, ValueError):
+                                    pass
+                        except OSError:
+                            pass
                         _write_progress(
                             f"Process exited (code {proc.returncode}),"
                             f" cumulative turns: {cumulative_turns}"

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -111,7 +111,7 @@ class ClaudeCodeController(DiscoveryController):
                 "CID=$(cat /workspace/.evaluator-container-id)\n"
                 "CANDIDATE=\"/tmp/candidate_$$.${EXT}\"\n"
                 "docker exec -i \"$CID\" tee \"$CANDIDATE\" < \"$PROGRAM_PATH\" > /dev/null\n"
-                f"timeout {timeout} docker exec \"$CID\" /benchmark/evaluate.sh \"$MODE\" \"$CANDIDATE\"\n"
+                f"timeout {timeout} docker exec \"$CID\" /benchmark/evaluate.sh \"$CANDIDATE\" \"$MODE\"\n"
                 "docker exec \"$CID\" rm -f \"$CANDIDATE\"\n"
             )
         script_path = workspace / "run_eval.sh"

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -384,7 +384,7 @@ class ClaudeCodeController(DiscoveryController):
             # Run process in a thread; poll solution file for checkpoints.
             run_future = loop.run_in_executor(None, _run_with_turn_limit)
             last_ckpt_content = initial_code
-            last_ckpt_iter = 0
+            ckpt_count = 0
             ckpt_interval = self.config.checkpoint_interval
 
             while not run_future.done():
@@ -397,7 +397,11 @@ class ClaudeCodeController(DiscoveryController):
                 if cur == last_ckpt_content or not cur.strip():
                     continue
                 last_ckpt_content = cur
-                iteration = max(cumulative_turns, last_ckpt_iter + 1)
+                ckpt_count += 1
+                # Use ckpt_count as the iteration proxy so checkpoint_callback
+                # fires reliably even during a single long segment where
+                # cumulative_turns stays 0 until the segment ends.
+                iteration = max(cumulative_turns, ckpt_count)
                 try:
                     pid = str(uuid.uuid4())
                     er = await self.evaluator.evaluate_program(cur, pid)
@@ -415,9 +419,8 @@ class ClaudeCodeController(DiscoveryController):
                     self.database.add(prog, iteration=iteration)
                     score = er.metrics.get("combined_score", "?")
                     _write_progress(f"[CHECKPOINT] turn ~{cumulative_turns}, score={score}")
-                    if checkpoint_callback and iteration >= last_ckpt_iter + ckpt_interval:
+                    if checkpoint_callback and ckpt_count % ckpt_interval == 0:
                         checkpoint_callback(iteration)
-                        last_ckpt_iter = iteration
                 except Exception:
                     logger.debug("Checkpoint eval failed", exc_info=True)
 

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -1,0 +1,296 @@
+"""Claude Code baseline controller.
+
+Runs Claude Code CLI inside a Docker container as a single-agent baseline,
+letting it iterate on the solution using the evaluator directly.  The
+framework's standard evaluator scores the final result.
+
+Docker is always required: --dangerously-skip-permissions needs isolation.
+
+For Docker evaluators, the container runs in --privileged DinD mode so
+Claude Code has its own isolated Docker daemon (no host socket mount).
+For Python evaluators, the container runs in simple --user mode.
+"""
+
+import asyncio
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Callable, Optional
+
+from skydiscover.evaluation import create_evaluator
+from skydiscover.search.base_database import Program
+from skydiscover.search.default_discovery_controller import (
+    DiscoveryController,
+    DiscoveryControllerInput,
+)
+
+logger = logging.getLogger(__name__)
+
+_RUNNER_IMAGE_DIR = Path(__file__).parent / "runner_image"
+
+
+class ClaudeCodeController(DiscoveryController):
+    """Discovery controller that delegates iteration to Claude Code CLI."""
+
+    def __init__(self, controller_input: DiscoveryControllerInput):
+        # Skip the parent __init__ which creates LLMPools we don't need.
+        self.config = controller_input.config
+        self.evaluation_file = controller_input.evaluation_file
+        self.database = controller_input.database
+        self.file_suffix = controller_input.file_suffix
+        self.output_dir = controller_input.output_dir
+
+        self.config.evaluator.evaluation_file = self.evaluation_file
+        self.config.evaluator.file_suffix = self.file_suffix
+        self.config.evaluator.is_image_mode = self.config.language == "image"
+
+        self.evaluator = create_evaluator(self.config.evaluator)
+
+        self.monitor_callback = None
+        self.feedback_reader = None
+        self.early_stopping_triggered = False
+        self.shutdown_event = None
+
+    def _ensure_image_built(self, image_name: str) -> None:
+        result = subprocess.run(
+            ["docker", "image", "inspect", image_name],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            logger.info(f"Building Claude Code runner image '{image_name}'...")
+            subprocess.run(
+                ["docker", "build", "-t", image_name, str(_RUNNER_IMAGE_DIR)],
+                check=True,
+            )
+
+    def _save_evaluator_image(self, workspace: Path, image_tag: str) -> None:
+        """Export the evaluator Docker image so the DinD daemon can load it."""
+        tar_path = workspace / ".evaluator-image.tar"
+        logger.info(f"Saving evaluator image '{image_tag}' for DinD...")
+        subprocess.run(
+            ["docker", "save", "-o", str(tar_path), image_tag],
+            check=True,
+        )
+
+    def _write_eval_script(
+        self, workspace: Path, eval_type: str, evaluator_image: str = "", timeout: int = 360
+    ) -> None:
+        """Write run_eval.sh that Claude Code can call to score a solution."""
+        if eval_type == "python":
+            script = (
+                "#!/bin/bash\nset -euo pipefail\n"
+                f"timeout {timeout} python3 /workspace/evaluator.py \"$1\"\n"
+            )
+        else:
+            # Docker evaluator: the entrypoint starts a persistent evaluator
+            # container and writes its ID to .evaluator-container-id. We use
+            # docker exec (like ContainerizedEvaluator) to inject the program
+            # via stdin and run evaluate.sh — no new container per eval call.
+            script = (
+                "#!/bin/bash\n"
+                "set -euo pipefail\n"
+                "PROGRAM_PATH=\"$1\"\n"
+                "MODE=\"${2:-train}\"\n"
+                "EXT=\"${PROGRAM_PATH##*.}\"\n"
+                "CID=$(cat /workspace/.evaluator-container-id)\n"
+                "CANDIDATE=\"/tmp/candidate_$$.${EXT}\"\n"
+                "docker exec -i \"$CID\" tee \"$CANDIDATE\" < \"$PROGRAM_PATH\" > /dev/null\n"
+                f"timeout {timeout} docker exec \"$CID\" /benchmark/evaluate.sh \"$MODE\" \"$CANDIDATE\"\n"
+                "docker exec \"$CID\" rm -f \"$CANDIDATE\"\n"
+            )
+        script_path = workspace / "run_eval.sh"
+        script_path.write_text(script)
+        script_path.chmod(0o755)
+
+    def _write_task_md(self, workspace: Path, suffix: str, max_turns: int = 0) -> None:
+        system_msg = getattr(self.config.context_builder, "system_message", "") or ""
+        eval_timeout = self.config.evaluator.timeout
+        content = (
+            "# SkyDiscover: Optimization Task\n\n"
+            f"You are an AI assistant iteratively improving a program to maximize its evaluation score. "
+            f"You have **{max_turns} turns** total — be mindful of this budget and make sure to fully "
+            f"implement and test your ideas before you run out of turns.\n\n"
+            "## Current solution\n\n"
+            f"`/workspace/solution{suffix}` — read it, understand it, modify it freely.\n\n"
+            "## How to evaluate\n\n"
+            "```bash\n"
+            f"bash /workspace/run_eval.sh /workspace/solution{suffix}\n"
+            "```\n\n"
+            "Output is JSON. The `combined_score` field is what you want to maximize "
+            f"(higher is better). The evaluator has a **{eval_timeout}s timeout** — "
+            f"if your solution takes longer than that, it will be killed and score zero.\n\n"
+            "## Task description\n\n"
+            f"{system_msg}\n\n"
+            "## Instructions\n\n"
+            "- Run the evaluator once to confirm the baseline score, then **start making changes immediately**.\n"
+            "- Don't spend more than 1-2 turns analyzing — get to trying improvements fast.\n"
+            "- After each change, evaluate and decide whether to keep or revert it.\n"
+            f"- Always keep `/workspace/solution{suffix}` set to your best solution so far.\n"
+            "- Aim to try several distinct approaches within your turn budget.\n"
+        )
+        (workspace / "TASK.md").write_text(content)
+
+    async def run_discovery(
+        self,
+        start_iteration: int,
+        max_iterations: int,
+        checkpoint_callback: Optional[Callable] = None,
+        **kwargs,
+    ) -> Optional[Program]:
+        db_config = self.database.config
+        image_name = getattr(db_config, "docker_image", "skydiscover-claude-code:latest")
+        max_turns = max_iterations
+
+        model = self.config.llm.models[0].name if self.config.llm.models else None
+        _CLAUDE_MODEL_PREFIXES = ("claude-", "sonnet", "opus", "haiku")
+        if model and not any(model.startswith(p) for p in _CLAUDE_MODEL_PREFIXES):
+            raise ValueError(
+                f"claude_code only supports Claude models, got: {model!r}. "
+                f"Set llm.models[0].name to a claude-* model or alias (sonnet, opus, haiku)."
+            )
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._ensure_image_built, image_name)
+
+        initial = self.database.get_best_program()
+        initial_code = initial.solution if initial else ""
+
+        tmp_base = os.path.expanduser("~/.tmp")
+        os.makedirs(tmp_base, exist_ok=True)
+        workspace = Path(tempfile.mkdtemp(dir=tmp_base))
+
+        try:
+            suffix = self.file_suffix
+            solution_path = workspace / f"solution{suffix}"
+            solution_path.write_text(initial_code)
+
+            eval_path = Path(self.evaluation_file)
+            is_docker_eval = eval_path.is_dir()
+
+            if is_docker_eval:
+                evaluator_image = self.evaluator.image_tag
+                eval_timeout = self.config.evaluator.timeout
+                self._write_eval_script(
+                    workspace, "docker", evaluator_image=evaluator_image, timeout=eval_timeout
+                )
+                # Export the evaluator image for the DinD daemon to load.
+                await loop.run_in_executor(
+                    None, self._save_evaluator_image, workspace, evaluator_image
+                )
+            else:
+                shutil.copy(eval_path, workspace / "evaluator.py")
+                eval_timeout = self.config.evaluator.timeout
+                self._write_eval_script(workspace, "python", timeout=eval_timeout)
+                req = eval_path.parent / "requirements.txt"
+                if req.exists():
+                    shutil.copy(req, workspace / "requirements.txt")
+
+            self._write_task_md(workspace, suffix, max_turns=max_turns)
+            task_content = (workspace / "TASK.md").read_text()
+
+            api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+            log_path = workspace / "claude.log"
+
+            pip_step = (
+                "pip install -q --no-warn-script-location -r /workspace/requirements.txt"
+                " >/dev/null 2>&1 && "
+                if (workspace / "requirements.txt").exists() else ""
+            )
+            model_flag = f" --model {shlex.quote(model)}" if model else ""
+            bash_cmd = (
+                f"{pip_step}"
+                f"claude -p {shlex.quote(task_content)}"
+                f" --max-turns {max_turns}"
+                f" --dangerously-skip-permissions"
+                f" --output-format stream-json"
+                f" --verbose"
+                f"{model_flag}"
+            )
+
+            if is_docker_eval:
+                # DinD mode: --privileged gives the container its own Docker
+                # daemon. The entrypoint starts dockerd, loads the evaluator
+                # image, then drops to a non-root user before running claude.
+                # Write bash_cmd to a script file so it doesn't get mangled
+                # by su -c argument expansion in the entrypoint.
+                run_script = workspace / ".run.sh"
+                run_script.write_text(f"#!/bin/bash\n{bash_cmd}\n")
+                run_script.chmod(0o755)
+                cmd = [
+                    "docker", "run", "--rm",
+                    "--privileged",
+                    "-e", "DIND=1",
+                    "-e", f"ANTHROPIC_API_KEY={api_key}",
+                    "-v", f"{workspace}:/workspace",
+                    "-w", "/workspace",
+                    image_name,
+                    "/workspace/.run.sh",
+                ]
+            else:
+                # Simple mode: no Docker needed inside the container.
+                cmd = [
+                    "docker", "run", "--rm",
+                    "--user", f"{os.getuid()}:{os.getgid()}",
+                    "-e", "HOME=/workspace",
+                    "-e", f"ANTHROPIC_API_KEY={api_key}",
+                    "-v", f"{workspace}:/workspace",
+                    "-w", "/workspace",
+                    "--entrypoint", "bash",
+                    image_name,
+                    "-c", bash_cmd,
+                ]
+
+            logger.info(
+                f"Starting Claude Code container (--max-turns {max_turns})\n"
+                f"  Monitor progress: tail -f {log_path} | cclean -t"
+                f"  (https://github.com/ariel-frischer/claude-clean)"
+            )
+
+            def _run_with_turn_limit() -> None:
+                with open(log_path, "w") as log_file:
+                    proc = subprocess.Popen(
+                        cmd, stdout=subprocess.PIPE, stderr=log_file
+                    )
+                    turn_count = 0
+                    for raw_line in proc.stdout:
+                        log_file.write(raw_line.decode("utf-8", errors="replace"))
+                        log_file.flush()
+                        if b'"type":"user"' in raw_line or b'"type": "user"' in raw_line:
+                            turn_count += 1
+                            logger.info(f"Claude Code turn {turn_count}/{max_turns}")
+                            if turn_count >= max_turns:
+                                logger.warning(
+                                    f"Reached max turns ({max_turns}), killing Claude Code process"
+                                )
+                                proc.kill()
+                                break
+                    proc.wait()
+
+            await loop.run_in_executor(None, _run_with_turn_limit)
+
+            final_code = solution_path.read_text()
+            program_id = str(uuid.uuid4())
+            eval_result = await self.evaluator.evaluate_program(final_code, program_id)
+
+            program = Program(
+                id=program_id,
+                solution=final_code,
+                language=self.config.language or "python",
+                metrics=eval_result.metrics,
+                iteration_found=0,
+                parent_id=initial.id if initial else None,
+                other_context_ids=[],
+                metadata={"claude_code_max_turns": max_turns},
+                artifacts=eval_result.artifacts,
+            )
+            self.database.add(program, iteration=0)
+
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
+
+        return self.database.get_best_program()

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -12,12 +12,15 @@ For Python evaluators, the container runs in simple --user mode.
 """
 
 import asyncio
+import json
 import logging
 import os
 import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Callable, Optional
@@ -82,9 +85,17 @@ class ClaudeCodeController(DiscoveryController):
     ) -> None:
         """Write run_eval.sh that Claude Code can call to score a solution."""
         if eval_type == "python":
+            # evaluator.py may not have a __main__ block — call evaluate() directly
+            # and print the result dict as JSON so Claude Code can parse it.
             script = (
                 "#!/bin/bash\nset -euo pipefail\n"
-                f"timeout {timeout} python3 /workspace/evaluator.py \"$1\"\n"
+                f"timeout {timeout} python3 - \"$1\" <<'PYEOF'\n"
+                "import sys, json\n"
+                "sys.path.insert(0, '/workspace')\n"
+                "import evaluator\n"
+                "result = evaluator.evaluate(sys.argv[1])\n"
+                "print(json.dumps(result))\n"
+                "PYEOF\n"
             )
         else:
             # Docker evaluator: the entrypoint starts a persistent evaluator
@@ -163,6 +174,7 @@ class ClaudeCodeController(DiscoveryController):
         tmp_base = os.path.expanduser("~/.tmp")
         os.makedirs(tmp_base, exist_ok=True)
         workspace = Path(tempfile.mkdtemp(dir=tmp_base))
+        container_name = f"skydiscover-cc-{uuid.uuid4().hex[:12]}"
 
         try:
             suffix = self.file_suffix
@@ -171,10 +183,10 @@ class ClaudeCodeController(DiscoveryController):
 
             eval_path = Path(self.evaluation_file)
             is_docker_eval = eval_path.is_dir()
+            eval_timeout = self.config.evaluator.timeout
 
             if is_docker_eval:
                 evaluator_image = self.evaluator.image_tag
-                eval_timeout = self.config.evaluator.timeout
                 self._write_eval_script(
                     workspace, "docker", evaluator_image=evaluator_image, timeout=eval_timeout
                 )
@@ -184,7 +196,6 @@ class ClaudeCodeController(DiscoveryController):
                 )
             else:
                 shutil.copy(eval_path, workspace / "evaluator.py")
-                eval_timeout = self.config.evaluator.timeout
                 self._write_eval_script(workspace, "python", timeout=eval_timeout)
                 req = eval_path.parent / "requirements.txt"
                 if req.exists():
@@ -193,36 +204,46 @@ class ClaudeCodeController(DiscoveryController):
             self._write_task_md(workspace, suffix, max_turns=max_turns)
             task_content = (workspace / "TASK.md").read_text()
 
-            api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+            api_key = os.environ.get("ANTHROPIC_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY environment variable is not set. "
+                    "Export it before running: export ANTHROPIC_API_KEY=sk-ant-..."
+                )
             log_path = workspace / "claude.log"
 
-            pip_step = (
-                "pip install -q --no-warn-script-location -r /workspace/requirements.txt"
-                " >/dev/null 2>&1 && "
-                if (workspace / "requirements.txt").exists() else ""
-            )
-            model_flag = f" --model {shlex.quote(model)}" if model else ""
-            bash_cmd = (
-                f"{pip_step}"
-                f"claude -p {shlex.quote(task_content)}"
-                f" --max-turns {max_turns}"
-                f" --dangerously-skip-permissions"
-                f" --output-format stream-json"
-                f" --verbose"
+            # Write prompt to a file — inlining it in bash -c breaks on
+            # backticks and quotes in the TASK.md content.
+            (workspace / ".prompt.txt").write_text(task_content)
+
+            model_flag = f"--model {shlex.quote(model)} " if model else ""
+
+            # Write a launcher script.  The prompt is fed via stdin
+            # (< .prompt.txt) to avoid shell quoting issues.
+            script_lines = ["#!/bin/bash"]
+            if (workspace / "requirements.txt").exists():
+                # Best-effort pip install — don't abort if it fails.
+                script_lines.append(
+                    "pip install -q --no-warn-script-location"
+                    " -r /workspace/requirements.txt >/dev/null 2>&1 || true"
+                )
+            script_lines.append(
+                f"exec claude -p - "
+                f"--max-turns {max_turns} "
+                f"--dangerously-skip-permissions "
+                f"--output-format stream-json "
+                f"--verbose "
                 f"{model_flag}"
+                f"< /workspace/.prompt.txt"
             )
+            run_script = workspace / ".run.sh"
+            run_script.write_text("\n".join(script_lines) + "\n")
+            run_script.chmod(0o755)
 
             if is_docker_eval:
-                # DinD mode: --privileged gives the container its own Docker
-                # daemon. The entrypoint starts dockerd, loads the evaluator
-                # image, then drops to a non-root user before running claude.
-                # Write bash_cmd to a script file so it doesn't get mangled
-                # by su -c argument expansion in the entrypoint.
-                run_script = workspace / ".run.sh"
-                run_script.write_text(f"#!/bin/bash\n{bash_cmd}\n")
-                run_script.chmod(0o755)
                 cmd = [
                     "docker", "run", "--rm",
+                    "--name", container_name,
                     "--privileged",
                     "-e", "DIND=1",
                     "-e", f"ANTHROPIC_API_KEY={api_key}",
@@ -232,9 +253,9 @@ class ClaudeCodeController(DiscoveryController):
                     "/workspace/.run.sh",
                 ]
             else:
-                # Simple mode: no Docker needed inside the container.
                 cmd = [
                     "docker", "run", "--rm",
+                    "--name", container_name,
                     "--user", f"{os.getuid()}:{os.getgid()}",
                     "-e", "HOME=/workspace",
                     "-e", f"ANTHROPIC_API_KEY={api_key}",
@@ -242,55 +263,230 @@ class ClaudeCodeController(DiscoveryController):
                     "-w", "/workspace",
                     "--entrypoint", "bash",
                     image_name,
-                    "-c", bash_cmd,
+                    "/workspace/.run.sh",
                 ]
 
+            # Wall-clock timeout: allow full eval timeout + 2 min thinking per turn.
+            # This ensures the turn budget is never cut short by the wall clock.
+            wall_timeout = max(max_turns * (120 + eval_timeout), 600)
+
+            out = Path(self.output_dir) if self.output_dir else None
+            progress_log = (out / "progress.log") if out else None
+            if out:
+                out.mkdir(parents=True, exist_ok=True)
+
+            # Lock ensures progress.log writes are safe whether called from the
+            # executor thread (_run_with_turn_limit) or the async checkpoint loop.
+            _progress_lock = threading.Lock()
+
+            def _write_progress(line: str) -> None:
+                """Append a timestamped line to progress.log and emit as INFO."""
+                ts = time.strftime("%H:%M:%S")
+                entry = f"[{ts}] {line}"
+                logger.info(entry)
+                if progress_log:
+                    with _progress_lock:
+                        with open(progress_log, "a") as f:
+                            f.write(entry + "\n")
+
+            _write_progress(
+                f"Run started — model={model or 'default'}, "
+                f"max_turns={max_turns}, wall_timeout={wall_timeout}s"
+            )
             logger.info(
-                f"Starting Claude Code container (--max-turns {max_turns})\n"
-                f"  Monitor progress: tail -f {log_path} | cclean -t"
-                f"  (https://github.com/ariel-frischer/claude-clean)"
+                f"Starting Claude Code container '{container_name}' "
+                f"(--max-turns {max_turns}, wall timeout {wall_timeout}s)\n"
+                f"  Monitor progress: tail -f {progress_log or log_path}"
             )
 
+            # Shared state modified only from the executor thread.
+            cumulative_turns = 0
+            total_cost_usd = 0.0
+            run_start = time.monotonic()
+
             def _run_with_turn_limit() -> None:
+                nonlocal cumulative_turns, total_cost_usd
+                start = time.monotonic()
                 with open(log_path, "w") as log_file:
                     proc = subprocess.Popen(
                         cmd, stdout=subprocess.PIPE, stderr=log_file
                     )
-                    turn_count = 0
-                    for raw_line in proc.stdout:
-                        log_file.write(raw_line.decode("utf-8", errors="replace"))
-                        log_file.flush()
-                        if b'"type":"user"' in raw_line or b'"type": "user"' in raw_line:
-                            turn_count += 1
-                            logger.info(f"Claude Code turn {turn_count}/{max_turns}")
-                            if turn_count >= max_turns:
-                                logger.warning(
-                                    f"Reached max turns ({max_turns}), killing Claude Code process"
+                    try:
+                        for raw_line in proc.stdout:
+                            log_file.write(raw_line.decode("utf-8", errors="replace"))
+                            log_file.flush()
+
+                            # Parse stream-json events.  --max-turns is per-segment
+                            # (Claude resets the budget after context compaction), so
+                            # we track cumulative turns from result events across all
+                            # segments to enforce the GLOBAL budget.
+                            try:
+                                evt = json.loads(raw_line)
+                            except (json.JSONDecodeError, ValueError):
+                                continue
+                            evt_type = evt.get("type")
+
+                            # Log tool calls so the user can follow along in
+                            # progress.log.  We don't use assistant events for turn
+                            # counting because a single logical turn may produce
+                            # multiple assistant messages (e.g. thinking + tool use).
+                            if evt_type == "assistant":
+                                elapsed = time.monotonic() - start
+                                tool_names = [
+                                    c.get("name", "")
+                                    for c in evt.get("message", {}).get("content", [])
+                                    if c.get("type") == "tool_use"
+                                ]
+                                if tool_names:
+                                    _write_progress(
+                                        f"Active → {', '.join(tool_names)}"
+                                        f" (elapsed {elapsed:.0f}s,"
+                                        f" turns so far ~{cumulative_turns})"
+                                    )
+
+                            elif evt_type == "result":
+                                # result fires once per claude -p segment; num_turns
+                                # is the authoritative turn count for that segment.
+                                seg_turns = evt.get("num_turns", 0)
+                                cumulative_turns += seg_turns
+                                seg_cost = evt.get("total_cost_usd", 0) or 0
+                                if seg_cost > total_cost_usd:
+                                    total_cost_usd = seg_cost
+                                subtype = evt.get("subtype", "")
+                                _write_progress(
+                                    f"Segment done ({subtype}): "
+                                    f"+{seg_turns} turns, "
+                                    f"{cumulative_turns}/{max_turns} cumulative, "
+                                    f"cost=${total_cost_usd:.4f}"
+                                )
+                                if cumulative_turns >= max_turns:
+                                    _write_progress(
+                                        f"Turn budget ({max_turns}) exhausted — stopping"
+                                    )
+                                    proc.kill()
+                                    break
+
+                            # Wall-clock safety net.
+                            elapsed = time.monotonic() - start
+                            if elapsed > wall_timeout:
+                                _write_progress(
+                                    f"Wall timeout ({wall_timeout}s) exceeded — stopping"
                                 )
                                 proc.kill()
                                 break
-                    proc.wait()
+                    finally:
+                        proc.wait()
+                        _write_progress(
+                            f"Process exited (code {proc.returncode}),"
+                            f" cumulative turns: {cumulative_turns}"
+                        )
 
-            await loop.run_in_executor(None, _run_with_turn_limit)
+            # Run process in a thread; poll solution file for checkpoints.
+            run_future = loop.run_in_executor(None, _run_with_turn_limit)
+            last_ckpt_content = initial_code
+            last_ckpt_iter = 0
+            ckpt_interval = self.config.checkpoint_interval
 
-            final_code = solution_path.read_text()
+            while not run_future.done():
+                await asyncio.sleep(60)
+                # Check if solution file changed → evaluate + checkpoint.
+                try:
+                    cur = solution_path.read_text()
+                except OSError:
+                    continue
+                if cur == last_ckpt_content or not cur.strip():
+                    continue
+                last_ckpt_content = cur
+                iteration = max(cumulative_turns, last_ckpt_iter + 1)
+                try:
+                    pid = str(uuid.uuid4())
+                    er = await self.evaluator.evaluate_program(cur, pid)
+                    prog = Program(
+                        id=pid,
+                        solution=cur,
+                        language=self.config.language or "python",
+                        metrics=er.metrics,
+                        iteration_found=iteration,
+                        parent_id=initial.id if initial else None,
+                        other_context_ids=[],
+                        metadata={"claude_code_checkpoint_turn": cumulative_turns},
+                        artifacts=er.artifacts,
+                    )
+                    self.database.add(prog, iteration=iteration)
+                    score = er.metrics.get("combined_score", "?")
+                    _write_progress(f"[CHECKPOINT] turn ~{cumulative_turns}, score={score}")
+                    if checkpoint_callback and iteration >= last_ckpt_iter + ckpt_interval:
+                        checkpoint_callback(iteration)
+                        last_ckpt_iter = iteration
+                except Exception:
+                    logger.debug("Checkpoint eval failed", exc_info=True)
+
+            await run_future  # propagate exceptions
+
+            # Final evaluation.
+            try:
+                final_code = solution_path.read_text()
+            except OSError:
+                final_code = initial_code
+            if not final_code.strip():
+                final_code = initial_code
+
             program_id = str(uuid.uuid4())
             eval_result = await self.evaluator.evaluate_program(final_code, program_id)
+            final_iter = max(cumulative_turns, 1)
 
             program = Program(
                 id=program_id,
                 solution=final_code,
                 language=self.config.language or "python",
                 metrics=eval_result.metrics,
-                iteration_found=0,
+                iteration_found=final_iter,
                 parent_id=initial.id if initial else None,
                 other_context_ids=[],
-                metadata={"claude_code_max_turns": max_turns},
+                metadata={
+                    "claude_code_max_turns": max_turns,
+                    "actual_turns": cumulative_turns,
+                },
                 artifacts=eval_result.artifacts,
             )
-            self.database.add(program, iteration=0)
+            self.database.add(program, iteration=final_iter)
+
+            if checkpoint_callback:
+                checkpoint_callback(final_iter)
+
+            # Preserve claude.log and write run summary.
+            run_elapsed = time.monotonic() - run_start
+            if out:
+                try:
+                    shutil.copy(log_path, out / "claude.log")
+                except OSError:
+                    pass
+                summary = {
+                    "model": model,
+                    "max_turns": max_turns,
+                    "actual_turns": cumulative_turns,
+                    "cost_usd": round(total_cost_usd, 4),
+                    "wall_seconds": round(run_elapsed, 1),
+                    "baseline_score": initial.metrics.get("combined_score") if initial and initial.metrics else None,
+                    "final_score": eval_result.metrics.get("combined_score"),
+                    "final_metrics": eval_result.metrics,
+                }
+                (out / "run_summary.json").write_text(
+                    json.dumps(summary, indent=2, default=str) + "\n"
+                )
+                _write_progress(
+                    f"Run complete: turns={cumulative_turns}/{max_turns}, "
+                    f"cost=${total_cost_usd:.4f}, "
+                    f"time={run_elapsed:.0f}s, "
+                    f"score={eval_result.metrics.get('combined_score', '?')}"
+                )
 
         finally:
+            # Kill container if still running (timeout, exception, etc.).
+            subprocess.run(
+                ["docker", "rm", "-f", container_name],
+                capture_output=True,
+            )
             shutil.rmtree(workspace, ignore_errors=True)
 
         return self.database.get_best_program()

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -497,40 +497,49 @@ class ClaudeCodeController(DiscoveryController):
 
             final_iter = max(actual_turns, 1)
             final_score_source = "final_eval"
+
+            # Try evaluating the last solution Claude wrote.  If it times out or
+            # errors (solution too slow), fall back to re-evaluating the best
+            # program's CODE from the database — a fresh evaluation, not a stored
+            # number, so the result cannot be gamed by checkpoint selection.
             program_id = str(uuid.uuid4())
             try:
                 eval_result = await self.evaluator.evaluate_program(final_code, program_id)
                 if eval_result.metrics.get("timeout") or eval_result.metrics.get("combined_score") is None:
                     raise ValueError("Final eval timed out or returned no score")
             except Exception as e:
-                # Fall back to best checkpoint score already in the database.
-                logger.warning(f"Final eval failed ({e}), falling back to best checkpoint score")
+                logger.warning(f"Final eval failed ({e}), re-evaluating best checkpoint code")
                 best = self.database.get_best_program()
-                if best and best.metrics and best.metrics.get("combined_score") is not None:
-                    eval_result = type("R", (), {"metrics": best.metrics, "artifacts": best.artifacts or {}})()
+                if best and best.solution and best.solution.strip():
                     final_code = best.solution
-                    program_id = best.id
-                    final_score_source = "best_checkpoint"
+                    program_id = str(uuid.uuid4())
+                    try:
+                        eval_result = await self.evaluator.evaluate_program(final_code, program_id)
+                        final_score_source = "best_program_reeval"
+                    except Exception as e2:
+                        logger.warning(f"Best program re-eval also failed ({e2})")
+                        eval_result = type("R", (), {"metrics": {}, "artifacts": {}})()
+                        final_score_source = "none"
                 else:
                     eval_result = type("R", (), {"metrics": {}, "artifacts": {}})()
                     final_score_source = "none"
 
-            if final_score_source == "final_eval":
-                program = Program(
-                    id=program_id,
-                    solution=final_code,
-                    language=self.config.language or "python",
-                    metrics=eval_result.metrics,
-                    iteration_found=final_iter,
-                    parent_id=initial.id if initial else None,
-                    other_context_ids=[],
-                    metadata={
-                        "claude_code_max_turns": max_turns,
-                        "actual_turns": actual_turns,
-                    },
-                    artifacts=eval_result.artifacts,
-                )
-                self.database.add(program, iteration=final_iter)
+            program = Program(
+                id=program_id,
+                solution=final_code,
+                language=self.config.language or "python",
+                metrics=eval_result.metrics,
+                iteration_found=final_iter,
+                parent_id=initial.id if initial else None,
+                other_context_ids=[],
+                metadata={
+                    "claude_code_max_turns": max_turns,
+                    "actual_turns": actual_turns,
+                    "final_score_source": final_score_source,
+                },
+                artifacts=eval_result.artifacts,
+            )
+            self.database.add(program, iteration=final_iter)
 
             if checkpoint_callback:
                 checkpoint_callback(final_iter)

--- a/skydiscover/search/claude_code/controller.py
+++ b/skydiscover/search/claude_code/controller.py
@@ -484,8 +484,10 @@ class ClaudeCodeController(DiscoveryController):
                 except OSError:
                     pass
 
-            # Final evaluation: always re-evaluate the best solution on disk so the
-            # reported score is reproducible (re-running best_program.py gives same #).
+            # Final evaluation: re-evaluate the solution on disk.
+            # If it times out or errors (e.g. solution too slow), fall back to the
+            # best program already in the database from mid-run checkpoints —
+            # that score is already verified and reliable.
             try:
                 final_code = solution_path.read_text()
             except OSError:
@@ -493,25 +495,42 @@ class ClaudeCodeController(DiscoveryController):
             if not final_code.strip():
                 final_code = initial_code
 
-            program_id = str(uuid.uuid4())
-            eval_result = await self.evaluator.evaluate_program(final_code, program_id)
             final_iter = max(actual_turns, 1)
+            final_score_source = "final_eval"
+            program_id = str(uuid.uuid4())
+            try:
+                eval_result = await self.evaluator.evaluate_program(final_code, program_id)
+                if eval_result.metrics.get("timeout") or eval_result.metrics.get("combined_score") is None:
+                    raise ValueError("Final eval timed out or returned no score")
+            except Exception as e:
+                # Fall back to best checkpoint score already in the database.
+                logger.warning(f"Final eval failed ({e}), falling back to best checkpoint score")
+                best = self.database.get_best_program()
+                if best and best.metrics and best.metrics.get("combined_score") is not None:
+                    eval_result = type("R", (), {"metrics": best.metrics, "artifacts": best.artifacts or {}})()
+                    final_code = best.solution
+                    program_id = best.id
+                    final_score_source = "best_checkpoint"
+                else:
+                    eval_result = type("R", (), {"metrics": {}, "artifacts": {}})()
+                    final_score_source = "none"
 
-            program = Program(
-                id=program_id,
-                solution=final_code,
-                language=self.config.language or "python",
-                metrics=eval_result.metrics,
-                iteration_found=final_iter,
-                parent_id=initial.id if initial else None,
-                other_context_ids=[],
-                metadata={
-                    "claude_code_max_turns": max_turns,
-                    "actual_turns": actual_turns,
-                },
-                artifacts=eval_result.artifacts,
-            )
-            self.database.add(program, iteration=final_iter)
+            if final_score_source == "final_eval":
+                program = Program(
+                    id=program_id,
+                    solution=final_code,
+                    language=self.config.language or "python",
+                    metrics=eval_result.metrics,
+                    iteration_found=final_iter,
+                    parent_id=initial.id if initial else None,
+                    other_context_ids=[],
+                    metadata={
+                        "claude_code_max_turns": max_turns,
+                        "actual_turns": actual_turns,
+                    },
+                    artifacts=eval_result.artifacts,
+                )
+                self.database.add(program, iteration=final_iter)
 
             if checkpoint_callback:
                 checkpoint_callback(final_iter)
@@ -531,6 +550,7 @@ class ClaudeCodeController(DiscoveryController):
                     "wall_seconds": round(run_elapsed, 1),
                     "baseline_score": initial.metrics.get("combined_score") if initial and initial.metrics else None,
                     "final_score": eval_result.metrics.get("combined_score"),
+                    "final_score_source": final_score_source,
                     "final_metrics": eval_result.metrics,
                 }
                 (out / "run_summary.json").write_text(
@@ -541,6 +561,7 @@ class ClaudeCodeController(DiscoveryController):
                     f"cost=${total_cost_usd:.4f}, "
                     f"time={run_elapsed:.0f}s, "
                     f"score={eval_result.metrics.get('combined_score', '?')}"
+                    f" (source={final_score_source})"
                 )
 
         finally:

--- a/skydiscover/search/claude_code/database.py
+++ b/skydiscover/search/claude_code/database.py
@@ -1,0 +1,26 @@
+"""Minimal database for the Claude Code baseline.
+
+Claude Code handles its own internal iteration loop, so this database
+just stores whatever the controller adds (typically one final result).
+
+# TODO: Consider adding a boilerplate no-op database option to the framework
+# so single-shot methods don't need to implement their own pass-through.
+"""
+
+from skydiscover.search.base_database import Program, ProgramDatabase
+
+
+class ClaudeCodeDatabase(ProgramDatabase):
+    def add(self, program: Program, iteration=None, **kwargs) -> str:
+        self.programs[program.id] = program
+        if iteration is not None:
+            self.last_iteration = max(self.last_iteration, iteration)
+        if self.config.db_path:
+            self._save_program(program)
+        self._update_best_program(program)
+        return program.id
+
+    def sample(self, num_context_programs=4, **kwargs):
+        # Not called by ClaudeCodeController, but required by the interface.
+        best = self.get_best_program()
+        return best, []

--- a/skydiscover/search/claude_code/runner_image/Dockerfile
+++ b/skydiscover/search/claude_code/runner_image/Dockerfile
@@ -21,11 +21,12 @@ RUN npm install -g @anthropic-ai/claude-code
 RUN pip3 install --no-cache-dir \
     numpy scipy sympy \
     jax optax \
-    torch --index-url https://download.pytorch.org/whl/cpu \
     scikit-learn numba \
     pandas matplotlib plotly \
     networkx cvxpy autograd pymoo \
-    PyWavelets
+    PyWavelets \
+ && pip3 install --no-cache-dir \
+    torch --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Non-root user for running Claude Code (it refuses --dangerously-skip-permissions
 # as root). Added to the docker group so it can talk to dockerd in DinD mode.

--- a/skydiscover/search/claude_code/runner_image/Dockerfile
+++ b/skydiscover/search/claude_code/runner_image/Dockerfile
@@ -16,6 +16,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN npm install -g @anthropic-ai/claude-code
 
+# Pre-install the full math toolkit so Claude has a capable Python environment
+# for all math benchmarks (optimization, signal processing, geometry, etc.).
+RUN pip3 install --no-cache-dir \
+    numpy scipy sympy \
+    jax optax \
+    torch --index-url https://download.pytorch.org/whl/cpu \
+    scikit-learn numba \
+    pandas matplotlib plotly \
+    networkx cvxpy autograd pymoo \
+    PyWavelets
+
 # Non-root user for running Claude Code (it refuses --dangerously-skip-permissions
 # as root). Added to the docker group so it can talk to dockerd in DinD mode.
 RUN useradd -m -s /bin/bash -G docker claude

--- a/skydiscover/search/claude_code/runner_image/Dockerfile
+++ b/skydiscover/search/claude_code/runner_image/Dockerfile
@@ -2,16 +2,16 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+# Install system deps, Node.js 20, and Claude Code in a single layer to keep
+# the image small.  ca-certificates is required for curl HTTPS connections.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip \
     docker.io \
     iptables \
     curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node.js 20
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
+    ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @anthropic-ai/claude-code

--- a/skydiscover/search/claude_code/runner_image/Dockerfile
+++ b/skydiscover/search/claude_code/runner_image/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip \
+    docker.io \
+    iptables \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root user for running Claude Code (it refuses --dangerously-skip-permissions
+# as root). Added to the docker group so it can talk to dockerd in DinD mode.
+RUN useradd -m -s /bin/bash -G docker claude
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["/entrypoint.sh"]

--- a/skydiscover/search/claude_code/runner_image/entrypoint.sh
+++ b/skydiscover/search/claude_code/runner_image/entrypoint.sh
@@ -39,9 +39,11 @@ if [ "${DIND:-}" = "1" ]; then
         echo "$EVAL_CID" > /workspace/.evaluator-container-id
     fi
 
-    # Make workspace writable by the claude user. chown fails on Docker
-    # Desktop for Mac volume mounts, so fall back to chmod.
-    chown -R claude:claude /workspace 2>/dev/null || chmod -R 777 /workspace 2>/dev/null || true
+    # Make workspace writable by the claude user, and keep it readable by
+    # the host user (who runs the controller) so solution.py can be read
+    # back for checkpointing and final evaluation.
+    chown -R claude:claude /workspace 2>/dev/null || true
+    chmod -R a+rX /workspace 2>/dev/null || true
 
     # Drop to non-root user. The controller writes the command to a
     # script file (.run.sh) to avoid quoting issues with su -c.

--- a/skydiscover/search/claude_code/runner_image/entrypoint.sh
+++ b/skydiscover/search/claude_code/runner_image/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${DIND:-}" = "1" ]; then
+    # Start Docker daemon in background (needed for Docker evaluators).
+    # Try overlay2 first (fast), fall back to vfs (always works, needed
+    # on Docker Desktop for Mac where overlay-on-overlay fails).
+    dockerd --host=unix:///var/run/docker.sock \
+            --storage-driver=overlay2 \
+            > /var/log/dockerd.log 2>&1 &
+    DOCKERD_PID=$!
+    sleep 2
+    if ! kill -0 $DOCKERD_PID 2>/dev/null; then
+        echo "overlay2 failed, falling back to vfs storage driver..." >> /var/log/dockerd.log
+        dockerd --host=unix:///var/run/docker.sock \
+                --storage-driver=vfs \
+                > /var/log/dockerd.log 2>&1 &
+        DOCKERD_PID=$!
+    fi
+
+    # Wait for daemon to be ready.
+    timeout=30
+    while ! docker info > /dev/null 2>&1; do
+        timeout=$((timeout - 1))
+        if [ "$timeout" -le 0 ]; then
+            echo "ERROR: dockerd failed to start" >&2
+            cat /var/log/dockerd.log >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    # Load evaluator image if a tar was provided, then start a persistent
+    # evaluator container. run_eval.sh uses docker exec against it.
+    if [ -f /workspace/.evaluator-image.tar ]; then
+        EVAL_IMAGE=$(docker load < /workspace/.evaluator-image.tar 2>/dev/null | grep -o '[^ ]*$')
+        rm -f /workspace/.evaluator-image.tar
+        EVAL_CID=$(docker run -d --rm --entrypoint sleep "$EVAL_IMAGE" infinity)
+        echo "$EVAL_CID" > /workspace/.evaluator-container-id
+    fi
+
+    # Make workspace writable by the claude user. chown fails on Docker
+    # Desktop for Mac volume mounts, so fall back to chmod.
+    chown -R claude:claude /workspace 2>/dev/null || chmod -R 777 /workspace 2>/dev/null || true
+
+    # Drop to non-root user. The controller writes the command to a
+    # script file (.run.sh) to avoid quoting issues with su -c.
+    exec su -s /bin/bash claude -c "export HOME=/workspace; $1"
+else
+    # Simple mode: just run the command (caller used --user).
+    exec "$@"
+fi

--- a/skydiscover/search/route.py
+++ b/skydiscover/search/route.py
@@ -10,6 +10,8 @@ import logging
 
 from skydiscover.search.adaevolve.controller import AdaEvolveController
 from skydiscover.search.adaevolve.database import AdaEvolveDatabase
+from skydiscover.search.claude_code.controller import ClaudeCodeController
+from skydiscover.search.claude_code.database import ClaudeCodeDatabase
 from skydiscover.search.beam_search.database import BeamSearchDatabase
 
 # Algorithm implementations
@@ -69,3 +71,7 @@ register_database("evox_meta", SearchStrategyDatabase)
 # GEPA Native: guided evolution with acceptance gating and merge
 register_database("gepa_native", GEPANativeDatabase)
 register_controller("gepa_native", GEPANativeController)
+
+# Claude Code: single-agent baseline running claude CLI in a container
+register_database("claude_code", ClaudeCodeDatabase)
+register_controller("claude_code", ClaudeCodeController)


### PR DESCRIPTION
## Summary

- Adds `claude_code` as a new search type that runs the Claude Code CLI inside a Docker container as a single-agent baseline
- Claude autonomously iterates on the solution using the evaluator directly, then the framework scores the final result
- Supports both Python evaluators (simple container mode) and Docker evaluators (privileged DinD mode)

## Usage

```bash
export ANTHROPIC_API_KEY=sk-ant-...
skydiscover-run initial.py evaluator.py -c config.yaml -s claude_code -m claude-sonnet-4-6 -i 50
```

`-i` / `--iterations` maps to `--max-turns` for the Claude Code CLI.

## What's in the PR

**New package** `skydiscover/search/claude_code/`:
- `controller.py` - runs Claude Code CLI in Docker, tracks turns via `result` events (not string matching), polls solution file for mid-run checkpoints, enforces wall-clock timeout, handles final eval with fallback to best checkpoint
- `database.py` - minimal pass-through (Claude handles its own iteration loop)
- `runner_image/Dockerfile` - Ubuntu 22.04, Node 20, Claude Code CLI, math toolkit pre-installed
- `runner_image/entrypoint.sh` - DinD bootstrap for Docker evaluators, simple passthrough for Python evaluators

**Registration** (3 small additions to existing files):
- `cli.py` - added `claude_code` to `_SEARCH_CHOICES`
- `config.py` - added `ClaudeCodeConfig` dataclass + entry in `_DB_CONFIG_BY_TYPE`
- `route.py` - imported and registered controller + database

## Key design decisions

- Skips parent `__init__` to avoid creating LLMPools (not needed for this baseline)
- Turn tracking uses `result` events from the stream-json output with `num_turns` field, which is the authoritative count from the CLI itself. This correctly handles context compaction (where `--max-turns` resets per segment)
- Checkpoints are captured by polling the solution file every 60s and evaluating via the framework evaluator
- Container is named `skydiscover-cc-<uuid>` and cleaned up via `docker rm -f` in a `finally` block

## Test plan

- All 144 existing tests pass
- Config round-trip verified (`from_dict`, `apply_overrides`)
- Registry wiring verified (controller + database registered correctly)
- Controller instantiation verified (all Runner-expected attributes present)
- Model validation verified (rejects non-Claude models)
- API key validation verified (raises immediately if unset)
- `request_shutdown()` verified (signal handler path works)
- End-to-end run on `circle_packing` benchmark (Python evaluator, 3 turns)
- End-to-end run on `signal_processing` benchmark (Docker evaluator / DinD mode, 5 turns, score improved from 0.499 to 0.669)

Made with [Cursor](https://cursor.com)