### PR TITLE
Fix Code and Parent Code tabs in live monitor

### DIFF
--- a/skydiscover/extras/monitor/dashboard.html
+++ b/skydiscover/extras/monitor/dashboard.html
@@ -1403,8 +1403,8 @@
     if (msg.program_id !== selectedId) return;
     const codeEl = document.getElementById('code-display');
     const parentEl = document.getElementById('parent-code-display');
-    if (codeEl) codeEl.textContent = msg.code || '(no code)';
-    if (parentEl) parentEl.textContent = msg.parent_code || '(no parent code)';
+    if (codeEl) codeEl.textContent = msg.solution || '(no code)';
+    if (parentEl) parentEl.textContent = msg.parent_solution || '(no parent code)';
 
     // Request image if this program has one (image evolution mode)
     const p = programMap[msg.program_id];


### PR DESCRIPTION
## Description
This PR fixes the issue where the Code and Parent Code tabs in the live monitor dashboard do not display the actual code content.

## Changes
- Fixed the `showProgramCode()` function.

## Fixes
Closes #66

## Testing
- Verified that clicking the "Code" tab displays the program's code
- Verified that clicking the "Parent Code" tab displays the parent program's code