### PR TITLE
Add `--summary-api-base` argument to replay viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.64.0",
     "numpy>=1.22.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.64.0",
     "numpy>=1.22.0",
-    "python-dotenv>=1.0.0",
+    "python-dotenv>=1.2.1",
 ]
 
 [project.optional-dependencies]

--- a/skydiscover/extras/monitor/server.py
+++ b/skydiscover/extras/monitor/server.py
@@ -199,11 +199,13 @@ class MonitorServer:
         self._summary_top_k = top_k
         self._summary_interval = interval
         self._summary_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="summary")
-        
+
         # Set initial placeholder text so UI knows summary is ready
         if not self._summary_text:
-            self._summary_text = "Click 'Refresh Summary' to generate an AI summary of the top programs."
-        
+            self._summary_text = (
+                "Click 'Refresh Summary' to generate an AI summary of the top programs."
+            )
+
         logger.info(
             f"AI summary configured: model={model}, top_k={top_k}, "
             f"interval={interval or 'manual'}, api_key={'set' if self._summary_api_key else 'MISSING'}"

--- a/skydiscover/extras/monitor/server.py
+++ b/skydiscover/extras/monitor/server.py
@@ -199,6 +199,11 @@ class MonitorServer:
         self._summary_top_k = top_k
         self._summary_interval = interval
         self._summary_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="summary")
+        
+        # Set initial placeholder text so UI knows summary is ready
+        if not self._summary_text:
+            self._summary_text = "Click 'Refresh Summary' to generate an AI summary of the top programs."
+        
         logger.info(
             f"AI summary configured: model={model}, top_k={top_k}, "
             f"interval={interval or 'manual'}, api_key={'set' if self._summary_api_key else 'MISSING'}"

--- a/skydiscover/extras/monitor/server.py
+++ b/skydiscover/extras/monitor/server.py
@@ -195,7 +195,7 @@ class MonitorServer:
         """
         self._summary_model = model
         self._summary_api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
-        self._summary_api_base = api_base
+        self._summary_api_base = api_base.rstrip("/")
         self._summary_top_k = top_k
         self._summary_interval = interval
         self._summary_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="summary")

--- a/skydiscover/extras/monitor/viewer.py
+++ b/skydiscover/extras/monitor/viewer.py
@@ -22,6 +22,8 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from dotenv import load_dotenv
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -200,6 +202,9 @@ def _to_monitor_format(prog: Dict, all_progs: Dict[str, Dict]) -> Dict:
 
 
 def main() -> None:
+    # Load environment variables from .env file
+    load_dotenv(verbose=True)
+    
     parser = argparse.ArgumentParser(
         description="Replay viewer for completed SkyDiscover runs",
     )
@@ -211,6 +216,11 @@ def main() -> None:
         default="",
         help="LLM model for per-program summaries (default: gpt-5-mini). "
         "Requires OPENAI_API_KEY env var.",
+    )
+    parser.add_argument(
+        "--summary-api-base",
+        default="https://api.openai.com/v1",
+        help="API base URL for summary generation (default: https://api.openai.com/v1)",
     )
     args = parser.parse_args()
 
@@ -241,7 +251,11 @@ def main() -> None:
     if not summary_model and os.environ.get("OPENAI_API_KEY"):
         summary_model = "gpt-5-mini"
     if summary_model:
-        server.configure_summary(model=summary_model, interval=0)
+        server.configure_summary(
+            model=summary_model,
+            api_base=args.summary_api_base,
+            interval=0
+        )
 
     server.start()
 

--- a/skydiscover/extras/monitor/viewer.py
+++ b/skydiscover/extras/monitor/viewer.py
@@ -204,7 +204,7 @@ def _to_monitor_format(prog: Dict, all_progs: Dict[str, Dict]) -> Dict:
 def main() -> None:
     # Load environment variables from .env file
     load_dotenv(verbose=True)
-    
+
     parser = argparse.ArgumentParser(
         description="Replay viewer for completed SkyDiscover runs",
     )
@@ -251,11 +251,7 @@ def main() -> None:
     if not summary_model and os.environ.get("OPENAI_API_KEY"):
         summary_model = "gpt-5-mini"
     if summary_model:
-        server.configure_summary(
-            model=summary_model,
-            api_base=args.summary_api_base,
-            interval=0
-        )
+        server.configure_summary(model=summary_model, api_base=args.summary_api_base, interval=0)
 
     server.start()
 

--- a/skydiscover/extras/monitor/viewer.py
+++ b/skydiscover/extras/monitor/viewer.py
@@ -203,7 +203,7 @@ def _to_monitor_format(prog: Dict, all_progs: Dict[str, Dict]) -> Dict:
 
 def main() -> None:
     # Load environment variables from .env file
-    load_dotenv(verbose=True)
+    load_dotenv()
 
     parser = argparse.ArgumentParser(
         description="Replay viewer for completed SkyDiscover runs",


### PR DESCRIPTION
## Summary
- Add `--summary-api-base` CLI argument to the replay viewer so users can point summary generation at custom API endpoints (defaults to `https://api.openai.com/v1`)
- Add `python-dotenv>=1.0.0` as a core dependency for `.env` file support
- Set initial placeholder text in the monitor summary panel

Tested by running the viewer with `--summary-api-base` set to a custom endpoint and verifying summary requests are routed correctly.

Closes #68