### PR TITLE
Adding internet and research paper tools for open world search tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ include = ["skydiscover*"]
 [tool.setuptools.package-data]
 skydiscover = [
     "context_builder/*/templates/*.txt",
+    "llm/tool_schemas/*.json",
     "search/evox/config/*.yaml",
     "search/evox/config/*.txt",
     "extras/external/defaults/*.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "tqdm>=4.64.0",
     "numpy>=1.22.0",
     "python-dotenv>=1.2.1",
+    "beautifulsoup4>=4.12.0",
+    "httpx>=0.27.0",
+    "requests>=2.31.0",
 ]
 
 [project.optional-dependencies]

--- a/skydiscover/context_builder/default/templates/agentic_system_message.txt
+++ b/skydiscover/context_builder/default/templates/agentic_system_message.txt
@@ -1,13 +1,51 @@
-You are in agentic mode. You have tools to explore the codebase before writing code.
+You are in agentic mode. You have tools to explore the codebase and the internet before writing code.
 
-Tools: read_file, search
+Tools: read_file, search, web_search, fetch_webpage, research_papers, run_command
 
 Workflow:
-1. Review the project structure.
-2. Read files that look useful.
-3. When ready, output your complete improved program as text.
+1. Review the project structure and read files that look useful.
+2. Use `web_search` to find relevant algorithms, papers, or implementations.
+3. Use `fetch_webpage` to download the full content of promising URLs returned by web_search.
+   Then use `read_file` with the returned path to read the saved page content.
+   Example:
+     Step A → web_search(query="circle packing algorithms")  → get list of URLs
+     Step B → fetch_webpage(url="https://en.wikipedia.org/wiki/Circle_packing")  → returns reference/web_<slug>.txt
+     Step C → read_file(path="reference/web_<slug>.txt")  → read the actual content
+4. Use `research_papers` to search for academic research relevant to the task.
+5. Use `run_command` to execute commands inside the codebase root and inspect outputs (e.g. run existing scripts, sanity-check data files, compute simple statistics).
+
+`run_command` usage:
+- Call with `{"command": "<your command>"}`. The tool runs in the codebase root and returns a transcript including:
+  - the command (`$ ...`)
+  - `[mode: exec]` (safe mode) or `[mode: shell]` (unsafe mode)
+  - `[exit code: N]`
+  - stdout/stderr output
+- Prefer short commands that print useful information (avoid huge outputs).
+- Before running a command, mentally estimate its runtime and output size. Only
+  run it if you expect it to finish quickly and print bounded output. For most
+  exploratory commands, target under 20 seconds and under a few dozen lines.
+- Do not run broad filesystem searches (`find /`, `find /home`, or recursive
+  scans from a high-level directory). Use the project structure, known paths,
+  `read_file`, or narrow commands scoped to the codebase root.
+
+Safe mode (default):
+- Intended for inspection and analysis.
+- Only a limited set of executables is allowed.
+- Shell operators like pipes and redirects (`|`, `>`, `&&`, `;`, etc.) are blocked.
+- Because safe mode does not invoke a shell, do not include pipes, redirects,
+  command chaining, `2>/dev/null`, `head`/`tail` pipelines, glob tricks, or
+  other shell syntax. If you need filtering, write a short Python command that
+  prints only the exact bounded information you need.
+
+Unsafe mode (optional):
+- You may set `unsafe: true` to run via the system shell only when the runtime allows it.
+- This enables pipes/redirects/compound commands, but is higher risk and should be used sparingly.
+- If unsafe mode is disabled, `unsafe: true` will fail with an error; fall back to safe mode.
+
+When you use `run_command`, read the output carefully and explicitly incorporate what you learned into your next step. If two tool attempts fail because of path or safe-mode restrictions, stop exploring and output the best complete solution you can from the prompt and prior context.
+6. When ready, output your complete improved program as text.
 
 The code you output must be complete and self-contained.
 It will be evaluated in isolation — do NOT import from the codebase.
 Inline any constants or logic you find in other files.
-Be efficient — don't read files you don't need.
+Be efficient — fetch only the pages most likely to contain algorithmic details.

--- a/skydiscover/llm/agentic_generator.py
+++ b/skydiscover/llm/agentic_generator.py
@@ -1,4 +1,4 @@
-"""Agentic code generator -- multi-turn tool-calling loop with read_file and search."""
+"""Agentic code generator -- multi-turn tool-calling loop with codebase and research tools."""
 
 import asyncio
 import concurrent.futures
@@ -50,7 +50,8 @@ class AgenticGenerator:
     """
     V0 [simple version]: Multi-turn tool-calling agent that explores a codebase before generating code.
 
-    Tools: read_file, search. When it stops calling tools, its text output
+    Tools: read_file, search, web_search, research_papers, fetch_webpage, run_command.
+    When it stops calling tools, its text output
     is the final answer. Returns None if no output is produced (caller falls
     back to direct generation).
     """
@@ -150,7 +151,7 @@ class AgenticGenerator:
                     },
                 )
 
-                result = self._run_tool(name, args, files_read)
+                result = await self._run_tool(name, args, files_read)
                 conversation.append(
                     {"role": "tool", "tool_call_id": tc_id, "content": result["content"]}
                 )
@@ -272,13 +273,53 @@ class AgenticGenerator:
     # Tools
     # ------------------------------------------------------------------
 
-    def _run_tool(self, name: str, args: Dict[str, Any], files_read: set) -> Dict[str, Any]:
+    async def _run_tool(self, name: str, args: Dict[str, Any], files_read: set) -> Dict[str, Any]:
         try:
             if name == "read_file":
                 return self._tool_read_file(args, files_read)
             elif name == "search":
                 return self._tool_search(args)
-            return _err(f"Unknown tool '{name}'. Available: read_file, search.")
+            elif name == "web_search":
+                from skydiscover.llm.tools.web_search_tool import web_search_handler
+
+                output, success = await web_search_handler(args)
+                return {"content": output, "_error": not success}
+            elif name in ("research_papers", "hf_papers"):
+                from skydiscover.llm.tools.papers_tool import research_papers_handler
+
+                output, success = await research_papers_handler(args)
+                return {"content": output, "_error": not success}
+            elif name == "fetch_webpage":
+                from skydiscover.llm.tools.fetch_webpage_tool import fetch_webpage_handler
+
+                output, success = await fetch_webpage_handler(
+                    args, codebase_root=self.config.codebase_root
+                )
+                return {"content": output, "_error": not success}
+            elif name == "run_command":
+                from skydiscover.llm.tools.run_command_tool import run_command_handler
+
+                if getattr(self.config, "run_command_enabled", True) is False:
+                    return _err(
+                        "run_command is disabled (agentic.run_command_enabled=false)."
+                    )
+                output, success = await run_command_handler(
+                    args,
+                    codebase_root=self.config.codebase_root,
+                    run_command_default_timeout=getattr(
+                        self.config, "run_command_default_timeout", 30
+                    ),
+                    run_command_max_timeout=getattr(self.config, "run_command_max_timeout", 120),
+                    run_command_max_output_chars=getattr(
+                        self.config, "run_command_max_output_chars", 20_000
+                    ),
+                    allow_unsafe_commands=getattr(self.config, "allow_unsafe_commands", False),
+                )
+                return {"content": output, "_error": not success}
+            return _err(
+                f"Unknown tool '{name}'. Available: read_file, search, web_search, "
+                "research_papers, fetch_webpage, run_command."
+            )
         except Exception as e:
             return _err(f"Tool '{name}' error: {e}")
 

--- a/skydiscover/llm/agentic_generator.py
+++ b/skydiscover/llm/agentic_generator.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import time
+from importlib import resources
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -20,9 +21,11 @@ from skydiscover.utils.code_utils import build_repo_map
 
 logger = logging.getLogger(__name__)
 
-_TOOL_SCHEMAS_PATH = Path(__file__).parent / "tool_schemas" / "agentic_tools.json"
-with open(_TOOL_SCHEMAS_PATH, "r") as _f:
-    TOOL_SCHEMAS = json.load(_f)
+TOOL_SCHEMAS = json.loads(
+    resources.files("skydiscover.llm.tool_schemas")
+    .joinpath("agentic_tools.json")
+    .read_text(encoding="utf-8")
+)
 
 # Responses API uses a flattened tool format (name/description/parameters at top level)
 TOOL_SCHEMAS_RESPONSES = [

--- a/skydiscover/llm/tool_schemas/agentic_tools.json
+++ b/skydiscover/llm/tool_schemas/agentic_tools.json
@@ -20,7 +20,9 @@
             "description": "End line (1-indexed). Omit for end of file."
           }
         },
-        "required": ["path"]
+        "required": [
+          "path"
+        ]
       }
     }
   },
@@ -41,7 +43,190 @@
             "description": "Glob to filter files (default: '*.py')."
           }
         },
-        "required": ["pattern"]
+        "required": [
+          "pattern"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "web_search",
+      "description": "Search the web for current information and return cited results.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 2
+          },
+          "allowed_domains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional allowlist of domains or URLs. Subdomains match."
+          },
+          "blocked_domains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional blocklist of domains or URLs. Subdomains match."
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "research_papers",
+      "description": "Discover ML research papers, analyze citations, search paper contents, and find linked resources.\n\nCombines HuggingFace Hub, arXiv, and Semantic Scholar. Use for exploring research areas, finding datasets for a task, tracing citation chains, or implementing a paper's approach.\n\nTypical flows:\n  search \u2192 read_paper \u2192 find_all_resources \u2192 hf_inspect_dataset\n  search \u2192 paper_details \u2192 citation_graph \u2192 read_paper (trace influence)\n  snippet_search \u2192 paper_details \u2192 read_paper (find specific claims)\n\nOperations:\n- trending: Get trending daily papers, optionally filter by topic keyword\n- search: Search papers. Uses HF by default (ML-tuned). Add date_from/min_citations/categories to use Semantic Scholar with filters\n- paper_details: Metadata, abstract, AI summary, github link\n- read_paper: Read paper contents \u2014 without section: abstract + TOC; with section: full text\n- citation_graph: Get references and citations for a paper with influence flags and citation intents\n- snippet_search: Semantic search over full-text passages from 12M+ papers\n- recommend: Find similar papers (single paper or positive/negative examples)\n- find_datasets: Find datasets linked to a paper\n- find_models: Find models linked to a paper\n- find_collections: Find collections that include a paper\n- find_all_resources: Parallel fetch of datasets + models + collections for a paper",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "enum": [
+              "trending",
+              "search",
+              "paper_details",
+              "read_paper",
+              "citation_graph",
+              "snippet_search",
+              "recommend",
+              "find_datasets",
+              "find_models",
+              "find_collections",
+              "find_all_resources"
+            ],
+            "description": "Operation to execute."
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query. Required for: search, snippet_search. Optional for: trending (filters by keyword). Supports boolean syntax for Semantic Scholar: '\"exact phrase\" term1 | term2'."
+          },
+          "arxiv_id": {
+            "type": "string",
+            "description": "ArXiv paper ID (e.g. '2305.18290'). Required for: paper_details, read_paper, citation_graph, find_datasets, find_models, find_collections, find_all_resources. Optional for: recommend (single-paper recs). Get IDs from search results first."
+          },
+          "section": {
+            "type": "string",
+            "description": "Section name or number to read (e.g. '3', 'Experiments', '4.2'). Optional for: read_paper. Without this, returns abstract + TOC."
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "citations",
+              "references",
+              "both"
+            ],
+            "description": "Direction for citation_graph. Default: both."
+          },
+          "date": {
+            "type": "string",
+            "description": "Date in YYYY-MM-DD format. Optional for: trending (defaults to recent papers)."
+          },
+          "date_from": {
+            "type": "string",
+            "description": "Start date (YYYY-MM-DD). Triggers Semantic Scholar search. For: search, snippet_search."
+          },
+          "date_to": {
+            "type": "string",
+            "description": "End date (YYYY-MM-DD). Triggers Semantic Scholar search. For: search, snippet_search."
+          },
+          "categories": {
+            "type": "string",
+            "description": "Field of study filter (e.g. 'Computer Science'). Triggers Semantic Scholar search."
+          },
+          "min_citations": {
+            "type": "integer",
+            "description": "Minimum citation count filter. Triggers Semantic Scholar search."
+          },
+          "sort_by": {
+            "type": "string",
+            "enum": [
+              "relevance",
+              "citationCount",
+              "publicationDate"
+            ],
+            "description": "Sort order for Semantic Scholar search. Default: relevance."
+          },
+          "positive_ids": {
+            "type": "string",
+            "description": "Comma-separated arxiv IDs for multi-paper recommendations. For: recommend."
+          },
+          "negative_ids": {
+            "type": "string",
+            "description": "Comma-separated arxiv IDs as negative examples. For: recommend."
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "downloads",
+              "likes",
+              "trending"
+            ],
+            "description": "Sort order for find_datasets and find_models. Default: downloads."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum results to return (default: 10, max: 50)."
+          }
+        },
+        "required": [
+          "operation"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "fetch_webpage",
+      "description": "Fetch a webpage by URL, convert it to plain text, and save it as a local file so you can read it with read_file.\n\nTypical flow:\n  1. web_search → get URLs\n  2. fetch_webpage(url=...) → get saved_path\n  3. read_file(path=saved_path) → read content\n\nThe saved file is plain text (HTML tags stripped), stored under reference/web_<slug>.txt inside the codebase root. Returns the relative path to use with read_file.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The full URL to fetch (must start with http:// or https://)."
+          }
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "run_command",
+      "description": "Execute a read-only shell command inside the codebase root directory and return its stdout/stderr output.\n\nUse this to inspect and analyse data files, run existing scripts, count lines, pretty-print JSON/CSV, profile code, etc.\n\nRestrictions:\n- Only a fixed allowlist of executables is permitted (python, python3, cat, head, tail, wc, grep, rg, find, ls, awk, sed, jq, sort, uniq, etc.).\n- Shell operators (|, &, ;, >, <) are NOT allowed — pipe output by saving to a file first or use awk/python inline.\n- Destructive commands (rm, mv, cp, pip, curl, wget, etc.) are blocked.\n- The working directory is always the codebase root.\n- Maximum runtime: 120 seconds (default 30).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "The command to run (e.g. 'python analyse.py', 'head -n 20 data/results.csv', 'wc -l src/*.py')."
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Optional wall-clock timeout in seconds (1–120, default 30)."
+          },
+          "unsafe": {
+            "type": "boolean",
+            "description": "If true, run the command through the system shell for full commandline capabilities (pipes, redirects, compound commands). Disabled by default."
+          }
+        },
+        "required": ["command"],
+        "additionalProperties": false
       }
     }
   }

--- a/skydiscover/llm/tools/fetch_webpage_tool.py
+++ b/skydiscover/llm/tools/fetch_webpage_tool.py
@@ -1,0 +1,281 @@
+"""fetch_webpage tool – download a URL and save it as a local text file.
+
+The agent calls this tool with a URL (typically from web_search results).
+The tool:
+  1. Fetches the page (with a sensible timeout + User-Agent).
+  2. Extracts readable text from HTML (strips scripts/styles/nav).
+  3. Saves the result as  <codebase_root>/reference/web_<slug>.txt
+  4. Returns the saved path so the agent can subsequently call read_file.
+
+The saved file is plain text, line-wrapped, and stays within a character
+budget so the agent's context does not blow up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import html as html_module
+import json
+import logging
+import os
+import re
+import time
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT_SECONDS = 30
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+# Directory (relative to codebase root) where pages are saved.
+REFERENCE_DIR = "reference"
+
+
+# ---------------------------------------------------------------------------
+# HTML → plain-text extraction
+# ---------------------------------------------------------------------------
+
+# Tags whose entire subtree we skip (content not useful for LLMs).
+_SKIP_TAGS = frozenset(
+    {
+        "script",
+        "style",
+        "noscript",
+        "head",
+        "header",
+        "footer",
+        "nav",
+        "aside",
+        "form",
+        "button",
+        "svg",
+        "img",
+        "figure",
+        "figcaption",
+        "iframe",
+        "meta",
+        "link",
+        "input",
+        "select",
+        "textarea",
+        "label",
+    }
+)
+
+# Block-level tags that get a blank line before/after.
+_BLOCK_TAGS = frozenset(
+    {
+        "p",
+        "div",
+        "section",
+        "article",
+        "main",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "li",
+        "dt",
+        "dd",
+        "blockquote",
+        "pre",
+        "code",
+        "tr",
+        "td",
+        "th",
+        "br",
+        "hr",
+    }
+)
+
+
+class _TextExtractor(HTMLParser):
+    """Extract plain text from HTML, skipping non-content subtrees."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._skip_depth: int = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag_lower = tag.lower()
+        if self._skip_depth > 0 or tag_lower in _SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if tag_lower in _BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag_lower = tag.lower()
+        if self._skip_depth > 0:
+            self._skip_depth -= 1
+            return
+        if tag_lower in _BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth == 0:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        raw = "".join(self._parts)
+        # Collapse runs of blank lines to at most 2.
+        cleaned = re.sub(r"\n{3,}", "\n\n", raw)
+        # Strip trailing whitespace on each line.
+        lines = [line.rstrip() for line in cleaned.splitlines()]
+        return "\n".join(lines).strip()
+
+
+def html_to_text(html_content: str) -> str:
+    """Convert HTML to clean plain text."""
+    extractor = _TextExtractor()
+    try:
+        extractor.feed(html_content)
+    except Exception:
+        # If the parser chokes, fall back to stripping all tags.
+        return re.sub(r"<[^>]+>", " ", html_content)
+    return extractor.get_text()
+
+
+# ---------------------------------------------------------------------------
+# URL → slug (for filename)
+# ---------------------------------------------------------------------------
+
+def _url_to_slug(url: str, max_len: int = 60) -> str:
+    """Turn a URL into a short, filesystem-safe slug."""
+    parsed = urlparse(url)
+    # Use host + path, strip scheme and query.
+    raw = (parsed.netloc + parsed.path).lower()
+    raw = re.sub(r"[^a-z0-9]+", "_", raw).strip("_")
+    if len(raw) > max_len:
+        # Keep the end (usually most specific) and prefix with a short hash.
+        h = hashlib.md5(url.encode()).hexdigest()[:6]
+        raw = h + "_" + raw[-(max_len - 7):]
+    return raw or hashlib.md5(url.encode()).hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# Core fetch + save logic
+# ---------------------------------------------------------------------------
+
+def fetch_and_save_webpage(url: str, codebase_root: str) -> dict[str, Any]:
+    """
+    Fetch *url*, convert to plain text, save under <codebase_root>/reference/,
+    and return a result dict with keys:
+      saved_path  – path relative to codebase root (for read_file)
+      abs_path    – absolute path on disk
+      url         – the fetched URL
+      char_count  – characters saved
+      truncated   – whether the content was truncated
+      error       – error message if fetch/parse failed (absent on success)
+    """
+    started = time.monotonic()
+
+    # ---- Fetch ----
+    try:
+        resp = requests.get(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            allow_redirects=True,
+        )
+        resp.raise_for_status()
+    except requests.exceptions.Timeout:
+        return {"error": f"Request timed out after {REQUEST_TIMEOUT_SECONDS}s: {url}"}
+    except requests.exceptions.RequestException as exc:
+        return {"error": f"HTTP error fetching {url}: {exc}"}
+
+    content_type = resp.headers.get("Content-Type", "")
+    is_html = "html" in content_type or not content_type
+
+    # ---- Extract text ----
+    if is_html:
+        text = html_to_text(resp.text)
+    else:
+        # For PDFs, plain text, etc., just use the raw text as-is.
+        text = resp.text
+
+    # ---- Build header ----
+    header_lines = [
+        f"# Fetched page: {url}",
+        f"# Content-Type: {content_type}",
+        f"# Fetched at: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}",
+        f"# Characters: {len(text)}",
+        "",
+    ]
+    full_content = "\n".join(header_lines) + text
+
+    # ---- Save to disk ----
+    ref_dir = os.path.join(codebase_root, REFERENCE_DIR)
+    os.makedirs(ref_dir, exist_ok=True)
+
+    slug = _url_to_slug(url)
+    filename = f"web_{slug}.txt"
+    abs_path = os.path.join(ref_dir, filename)
+    rel_path = os.path.join(REFERENCE_DIR, filename)
+
+    try:
+        with open(abs_path, "w", encoding="utf-8", errors="replace") as fh:
+            fh.write(full_content)
+    except OSError as exc:
+        return {"error": f"Failed to write {abs_path}: {exc}"}
+
+    elapsed = time.monotonic() - started
+    logger.info(
+        "fetch_webpage: saved %s → %s (%d chars, %.1fs)",
+        url,
+        rel_path,
+        len(full_content),
+        elapsed,
+    )
+
+    return {
+        "saved_path": rel_path,
+        "abs_path": abs_path,
+        "url": url,
+        "char_count": len(full_content),
+        "duration_seconds": elapsed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool handler (async, called from agentic_generator._run_tool)
+# ---------------------------------------------------------------------------
+
+async def fetch_webpage_handler(
+    arguments: dict[str, Any],
+    codebase_root: str,
+    **_kw: Any,
+) -> tuple[str, bool]:
+    """Async handler called by the agentic loop."""
+    url = arguments.get("url", "").strip()
+    if not url:
+        return "Error: fetch_webpage requires a 'url' argument.", False
+    if not (url.startswith("http://") or url.startswith("https://")):
+        return "Error: URL must start with http:// or https://", False
+    if not codebase_root:
+        return "Error: codebase_root not configured – cannot save file.", False
+
+    result = await asyncio.to_thread(fetch_and_save_webpage, url, codebase_root)
+
+    if "error" in result:
+        return f"Error fetching webpage: {result['error']}", False
+
+    msg = (
+        f"Webpage saved successfully.\n"
+        f"  URL:         {result['url']}\n"
+        f"  Saved to:    {result['saved_path']}\n"
+        f"  Characters:  {result['char_count']}\n"
+        f"  Duration:    {result['duration_seconds']:.1f}s\n\n"
+        f"Use read_file with path='{result['saved_path']}' to read the content."
+    )
+    return msg, True

--- a/skydiscover/llm/tools/papers_tool.py
+++ b/skydiscover/llm/tools/papers_tool.py
@@ -1,0 +1,1301 @@
+"""
+HF Papers Tool — Discover papers, read their contents, and find linked resources.
+
+Operations: trending, search, paper_details, read_paper,
+            find_datasets, find_models, find_collections, find_all_resources,
+            citation_graph, snippet_search, recommend
+"""
+
+import asyncio
+import os
+import re
+import time
+from typing import Any
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+ToolResult = dict[str, Any]
+
+HF_API = "https://huggingface.co/api"
+ARXIV_HTML = "https://arxiv.org/html"
+AR5IV_HTML = "https://ar5iv.labs.arxiv.org/html"
+
+DEFAULT_LIMIT = 10
+MAX_LIMIT = 50
+MAX_SUMMARY_LEN = 300
+MAX_SECTION_PREVIEW_LEN = 280
+MAX_SECTION_TEXT_LEN = 8000
+
+SORT_MAP = {
+    "downloads": "downloads",
+    "likes": "likes",
+    "trending": "trendingScore",
+}
+
+# ---------------------------------------------------------------------------
+# Semantic Scholar API
+# ---------------------------------------------------------------------------
+
+S2_API = "https://api.semanticscholar.org"
+S2_API_KEY = os.environ.get("S2_API_KEY")
+S2_HEADERS: dict[str, str] = {"x-api-key": S2_API_KEY} if S2_API_KEY else {}
+S2_TIMEOUT = 12
+_s2_last_request: float = 0.0
+
+# Shared response cache (survives across sessions, keyed by (path, params_tuple))
+_s2_cache: dict[str, Any] = {}
+_S2_CACHE_MAX = 500
+
+
+def _s2_paper_id(arxiv_id: str) -> str:
+    """Convert bare arxiv ID to S2 format."""
+    return f"ARXIV:{arxiv_id}"
+
+
+def _s2_cache_key(path: str, params: dict | None) -> str:
+    """Build a hashable cache key from path + sorted params."""
+    p = tuple(sorted((params or {}).items()))
+    return f"{path}:{p}"
+
+
+async def _s2_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    **kwargs: Any,
+) -> httpx.Response | None:
+    """S2 request with 2 retries on 429/5xx. Rate-limited only when using API key."""
+    global _s2_last_request
+    url = f"{S2_API}{path}"
+    kwargs.setdefault("headers", {}).update(S2_HEADERS)
+    kwargs.setdefault("timeout", S2_TIMEOUT)
+
+    for attempt in range(3):
+        # Rate limit only when authenticated (1 req/s for search, 10 req/s for others)
+        if S2_API_KEY:
+            min_interval = 1.0 if "search" in path else 0.1
+            elapsed = time.monotonic() - _s2_last_request
+            if elapsed < min_interval:
+                await asyncio.sleep(min_interval - elapsed)
+        _s2_last_request = time.monotonic()
+
+        try:
+            resp = await client.request(method, url, **kwargs)
+            if resp.status_code == 429:
+                if attempt < 2:
+                    await asyncio.sleep(5)
+                    continue
+                return None
+            if resp.status_code >= 500:
+                if attempt < 2:
+                    await asyncio.sleep(3)
+                    continue
+                return None
+            return resp
+        except (httpx.RequestError, httpx.HTTPStatusError):
+            if attempt < 2:
+                await asyncio.sleep(3)
+                continue
+            return None
+    return None
+
+
+async def _s2_get_json(
+    client: httpx.AsyncClient, path: str, params: dict | None = None,
+) -> dict | None:
+    """Cached S2 GET returning parsed JSON or None."""
+    key = _s2_cache_key(path, params)
+    if key in _s2_cache:
+        return _s2_cache[key]
+
+    resp = await _s2_request(client, "GET", path, params=params or {})
+    if resp and resp.status_code == 200:
+        data = resp.json()
+        if len(_s2_cache) < _S2_CACHE_MAX:
+            _s2_cache[key] = data
+        return data
+    return None
+
+
+async def _s2_get_paper(
+    client: httpx.AsyncClient, arxiv_id: str, fields: str,
+) -> dict | None:
+    """Fetch a single paper from S2 by arxiv ID. Returns None on failure."""
+    return await _s2_get_json(
+        client,
+        f"/graph/v1/paper/{_s2_paper_id(arxiv_id)}",
+        {"fields": fields},
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTML paper parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_paper_html(html: str) -> dict[str, Any]:
+    """Parse arxiv HTML into structured sections.
+
+    Returns:
+        {
+            "title": str,
+            "abstract": str,
+            "sections": [{"id": str, "title": str, "level": int, "text": str}],
+        }
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Title
+    title_el = soup.find("h1", class_="ltx_title")
+    title = title_el.get_text(strip=True).removeprefix("Title:") if title_el else ""
+
+    # Abstract
+    abstract_el = soup.find("div", class_="ltx_abstract")
+    abstract = ""
+    if abstract_el:
+        # Skip the "Abstract" heading itself
+        for child in abstract_el.children:
+            if isinstance(child, Tag) and child.name in ("h6", "h2", "h3", "p", "span"):
+                if child.get_text(strip=True).lower() == "abstract":
+                    continue
+            if isinstance(child, Tag) and child.name == "p":
+                abstract += child.get_text(separator=" ", strip=True) + " "
+        abstract = abstract.strip()
+
+    # Sections — collect h2/h3 headings and text between them
+    sections: list[dict[str, Any]] = []
+    headings = soup.find_all(["h2", "h3"], class_=lambda c: c and "ltx_title" in c)
+
+    for heading in headings:
+        level = 2 if heading.name == "h2" else 3
+        heading_text = heading.get_text(separator=" ", strip=True)
+
+        # Collect text from siblings until next heading of same or higher level
+        text_parts: list[str] = []
+        sibling = heading.find_next_sibling()
+        while sibling:
+            if isinstance(sibling, Tag):
+                if sibling.name in ("h2", "h3") and "ltx_title" in (
+                    sibling.get("class") or []
+                ):
+                    break
+                # Also stop at h2 if we're collecting h3 content
+                if sibling.name == "h2" and level == 3:
+                    break
+                text_parts.append(sibling.get_text(separator=" ", strip=True))
+            sibling = sibling.find_next_sibling()
+
+        # Also check parent section element for contained paragraphs
+        parent_section = heading.find_parent("section")
+        if parent_section and not text_parts:
+            for p in parent_section.find_all("p", recursive=False):
+                text_parts.append(p.get_text(separator=" ", strip=True))
+
+        section_text = "\n\n".join(t for t in text_parts if t)
+
+        # Extract section number from heading text (e.g., "4 Experiments" → "4")
+        num_match = re.match(r"^([A-Z]?\d+(?:\.\d+)*)\s", heading_text)
+        section_id = num_match.group(1) if num_match else ""
+
+        sections.append(
+            {
+                "id": section_id,
+                "title": heading_text,
+                "level": level,
+                "text": section_text,
+            }
+        )
+
+    return {"title": title, "abstract": abstract, "sections": sections}
+
+
+def _find_section(sections: list[dict], query: str) -> dict | None:
+    """Find a section by number or name (fuzzy)."""
+    query_lower = query.lower().strip()
+
+    # Exact match on section number
+    for s in sections:
+        if s["id"] == query_lower or s["id"] == query:
+            return s
+
+    # Exact match on title
+    for s in sections:
+        if query_lower == s["title"].lower():
+            return s
+
+    # Substring match on title
+    for s in sections:
+        if query_lower in s["title"].lower():
+            return s
+
+    # Number prefix match (e.g., "4" matches "4.1", "4.2", etc. — return parent)
+    for s in sections:
+        if s["id"].startswith(query_lower + ".") or s["id"] == query_lower:
+            return s
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_description(text: str) -> str:
+    """Strip HTML card artifacts and collapse whitespace from HF API descriptions."""
+    text = re.sub(r"[\t]+", " ", text)
+    text = re.sub(r"\n{2,}", "\n", text)
+    return text.strip()
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
+
+
+def _format_paper_list(
+    papers: list, title: str, date: str | None = None, query: str | None = None
+) -> str:
+    lines = [f"# {title}"]
+    if date:
+        lines[0] += f" ({date})"
+    if query:
+        lines.append(f"Filtered by: '{query}'")
+    lines.append(f"Showing {len(papers)} paper(s)\n")
+
+    for i, item in enumerate(papers, 1):
+        paper = item.get("paper", item)
+        arxiv_id = paper.get("id", "")
+        paper_title = paper.get("title", "Unknown")
+        upvotes = paper.get("upvotes", 0)
+        summary = paper.get("ai_summary") or _truncate(
+            paper.get("summary", ""), MAX_SUMMARY_LEN
+        )
+        keywords = paper.get("ai_keywords") or []
+        github = paper.get("githubRepo") or ""
+        stars = paper.get("githubStars") or 0
+
+        lines.append(f"## {i}. {paper_title}")
+        lines.append(f"**arxiv_id:** {arxiv_id} | **upvotes:** {upvotes}")
+        lines.append(f"https://huggingface.co/papers/{arxiv_id}")
+        if keywords:
+            lines.append(f"**Keywords:** {', '.join(keywords[:5])}")
+        if github:
+            lines.append(f"**GitHub:** {github} ({stars} stars)")
+        if summary:
+            lines.append(f"**Summary:** {_truncate(summary, MAX_SUMMARY_LEN)}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_paper_detail(paper: dict, s2_data: dict | None = None) -> str:
+    arxiv_id = paper.get("id", "")
+    title = paper.get("title", "Unknown")
+    upvotes = paper.get("upvotes", 0)
+    ai_summary = paper.get("ai_summary") or ""
+    summary = paper.get("summary", "")
+    keywords = paper.get("ai_keywords") or []
+    github = paper.get("githubRepo") or ""
+    stars = paper.get("githubStars") or 0
+    authors = paper.get("authors") or []
+
+    lines = [f"# {title}"]
+    meta_parts = [f"**arxiv_id:** {arxiv_id}", f"**upvotes:** {upvotes}"]
+    if s2_data:
+        cites = s2_data.get("citationCount", 0)
+        influential = s2_data.get("influentialCitationCount", 0)
+        meta_parts.append(f"**citations:** {cites} ({influential} influential)")
+    lines.append(" | ".join(meta_parts))
+    lines.append(f"https://huggingface.co/papers/{arxiv_id}")
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}")
+
+    if authors:
+        names = [a.get("name", "") for a in authors[:10]]
+        author_str = ", ".join(n for n in names if n)
+        if len(authors) > 10:
+            author_str += f" (+{len(authors) - 10} more)"
+        lines.append(f"**Authors:** {author_str}")
+
+    if keywords:
+        lines.append(f"**Keywords:** {', '.join(keywords)}")
+    if s2_data and s2_data.get("s2FieldsOfStudy"):
+        fields = [f["category"] for f in s2_data["s2FieldsOfStudy"] if f.get("category")]
+        if fields:
+            lines.append(f"**Fields:** {', '.join(fields)}")
+    if s2_data and s2_data.get("venue"):
+        lines.append(f"**Venue:** {s2_data['venue']}")
+    if github:
+        lines.append(f"**GitHub:** {github} ({stars} stars)")
+
+    if s2_data and s2_data.get("tldr"):
+        tldr_text = s2_data["tldr"].get("text", "")
+        if tldr_text:
+            lines.append(f"\n## TL;DR\n{tldr_text}")
+    if ai_summary:
+        lines.append(f"\n## AI Summary\n{ai_summary}")
+    if summary:
+        lines.append(f"\n## Abstract\n{_truncate(summary, 500)}")
+
+    lines.append(
+        "\n**Next:** Use read_paper to read specific sections, find_all_resources for linked datasets/models, "
+        "or citation_graph to trace references and citations."
+    )
+    return "\n".join(lines)
+
+
+def _format_read_paper_toc(parsed: dict[str, Any], arxiv_id: str) -> str:
+    """Format TOC view: abstract + section list with previews."""
+    lines = [f"# {parsed['title']}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+
+    if parsed["abstract"]:
+        lines.append(f"## Abstract\n{parsed['abstract']}\n")
+
+    lines.append("## Sections")
+    for s in parsed["sections"]:
+        prefix = "  " if s["level"] == 3 else ""
+        preview = (
+            _truncate(s["text"], MAX_SECTION_PREVIEW_LEN) if s["text"] else "(empty)"
+        )
+        lines.append(f"{prefix}- **{s['title']}**: {preview}")
+
+    lines.append(
+        '\nCall read_paper with section parameter (e.g. section="4" or section="Experiments") to read a specific section.'
+    )
+    return "\n".join(lines)
+
+
+def _format_read_paper_section(section: dict, arxiv_id: str) -> str:
+    """Format a single section's full text."""
+    lines = [f"# {section['title']}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+
+    text = section["text"]
+    if len(text) > MAX_SECTION_TEXT_LEN:
+        text = (
+            text[:MAX_SECTION_TEXT_LEN]
+            + f"\n\n... (truncated at {MAX_SECTION_TEXT_LEN} chars)"
+        )
+
+    lines.append(text if text else "(This section has no extractable text content.)")
+    return "\n".join(lines)
+
+
+def _format_datasets(datasets: list, arxiv_id: str, sort: str) -> str:
+    lines = [f"# Datasets linked to paper {arxiv_id}"]
+    lines.append(f"https://huggingface.co/papers/{arxiv_id}")
+    lines.append(f"Showing {len(datasets)} dataset(s), sorted by {sort}\n")
+
+    for i, ds in enumerate(datasets, 1):
+        ds_id = ds.get("id", "unknown")
+        downloads = ds.get("downloads", 0)
+        likes = ds.get("likes", 0)
+        desc = _truncate(_clean_description(ds.get("description") or ""), MAX_SUMMARY_LEN)
+        tags = ds.get("tags") or []
+        interesting = [t for t in tags if not t.startswith(("arxiv:", "region:"))][:5]
+
+        lines.append(f"**{i}. [{ds_id}](https://huggingface.co/datasets/{ds_id})**")
+        lines.append(f"   Downloads: {downloads:,} | Likes: {likes}")
+        if interesting:
+            lines.append(f"   Tags: {', '.join(interesting)}")
+        if desc:
+            lines.append(f"   {desc}")
+        lines.append("")
+
+    if datasets:
+        top = datasets[0].get("id", "")
+        lines.append(f'**Inspect top dataset:** hf_inspect_dataset(dataset="{top}")')
+    return "\n".join(lines)
+
+
+def _format_datasets_compact(datasets: list) -> str:
+    if not datasets:
+        return "## Datasets\nNone found"
+    lines = [f"## Datasets ({len(datasets)})"]
+    for ds in datasets:
+        lines.append(
+            f"- **{ds.get('id', '?')}** ({ds.get('downloads', 0):,} downloads)"
+        )
+    return "\n".join(lines)
+
+
+def _format_models(models: list, arxiv_id: str, sort: str) -> str:
+    lines = [f"# Models linked to paper {arxiv_id}"]
+    lines.append(f"https://huggingface.co/papers/{arxiv_id}")
+    lines.append(f"Showing {len(models)} model(s), sorted by {sort}\n")
+
+    for i, m in enumerate(models, 1):
+        model_id = m.get("id", "unknown")
+        downloads = m.get("downloads", 0)
+        likes = m.get("likes", 0)
+        pipeline = m.get("pipeline_tag") or ""
+        library = m.get("library_name") or ""
+
+        lines.append(f"**{i}. [{model_id}](https://huggingface.co/{model_id})**")
+        meta = f"   Downloads: {downloads:,} | Likes: {likes}"
+        if pipeline:
+            meta += f" | Task: {pipeline}"
+        if library:
+            meta += f" | Library: {library}"
+        lines.append(meta)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_models_compact(models: list) -> str:
+    if not models:
+        return "## Models\nNone found"
+    lines = [f"## Models ({len(models)})"]
+    for m in models:
+        pipeline = m.get("pipeline_tag") or ""
+        suffix = f" ({pipeline})" if pipeline else ""
+        lines.append(
+            f"- **{m.get('id', '?')}** ({m.get('downloads', 0):,} downloads){suffix}"
+        )
+    return "\n".join(lines)
+
+
+def _format_collections(collections: list, arxiv_id: str) -> str:
+    lines = [f"# Collections containing paper {arxiv_id}"]
+    lines.append(f"Showing {len(collections)} collection(s)\n")
+
+    for i, c in enumerate(collections, 1):
+        slug = c.get("slug", "")
+        title = c.get("title", "Untitled")
+        upvotes = c.get("upvotes", 0)
+        owner = c.get("owner", {}).get("name", "")
+        desc = _truncate(c.get("description") or "", MAX_SUMMARY_LEN)
+        num_items = len(c.get("items", []))
+
+        lines.append(f"**{i}. {title}**")
+        lines.append(f"   By: {owner} | Upvotes: {upvotes} | Items: {num_items}")
+        lines.append(f"   https://huggingface.co/collections/{slug}")
+        if desc:
+            lines.append(f"   {desc}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_collections_compact(collections: list) -> str:
+    if not collections:
+        return "## Collections\nNone found"
+    lines = [f"## Collections ({len(collections)})"]
+    for c in collections:
+        title = c.get("title", "Untitled")
+        owner = c.get("owner", {}).get("name", "")
+        upvotes = c.get("upvotes", 0)
+        lines.append(f"- **{title}** by {owner} ({upvotes} upvotes)")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Operation handlers
+# ---------------------------------------------------------------------------
+
+
+def _error(message: str) -> ToolResult:
+    return {
+        "formatted": message,
+        "totalResults": 0,
+        "resultsShared": 0,
+        "isError": True,
+    }
+
+
+def _validate_arxiv_id(args: dict) -> str | None:
+    """Return arxiv_id or None if missing."""
+    return args.get("arxiv_id")
+
+
+async def _op_trending(args: dict[str, Any], limit: int) -> ToolResult:
+    date = args.get("date")
+    query = args.get("query")
+
+    params: dict[str, Any] = {"limit": limit if not query else max(limit * 3, 30)}
+    if date:
+        params["date"] = date
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(f"{HF_API}/daily_papers", params=params)
+        resp.raise_for_status()
+        papers = resp.json()
+
+    if query:
+        q = query.lower()
+        papers = [
+            p
+            for p in papers
+            if q in p.get("title", "").lower()
+            or q in p.get("paper", {}).get("title", "").lower()
+            or q in p.get("paper", {}).get("summary", "").lower()
+            or any(
+                q in kw.lower() for kw in (p.get("paper", {}).get("ai_keywords") or [])
+            )
+        ]
+
+    papers = papers[:limit]
+    if not papers:
+        msg = "No trending papers found"
+        if query:
+            msg += f" matching '{query}'"
+        if date:
+            msg += f" for {date}"
+        return {"formatted": msg, "totalResults": 0, "resultsShared": 0}
+
+    formatted = _format_paper_list(papers, "Trending Papers", date=date, query=query)
+    return {
+        "formatted": formatted,
+        "totalResults": len(papers),
+        "resultsShared": len(papers),
+    }
+
+
+def _format_s2_paper_list(papers: list[dict], title: str) -> str:
+    """Format a list of S2 paper results."""
+    lines = [f"# {title}"]
+    lines.append(f"Showing {len(papers)} result(s)\n")
+
+    for i, paper in enumerate(papers, 1):
+        ptitle = paper.get("title") or "(untitled)"
+        year = paper.get("year") or "?"
+        cites = paper.get("citationCount", 0)
+        venue = paper.get("venue") or ""
+        ext_ids = paper.get("externalIds") or {}
+        aid = ext_ids.get("ArXiv", "")
+        tldr = (paper.get("tldr") or {}).get("text", "")
+
+        lines.append(f"### {i}. {ptitle}")
+        meta = [f"Year: {year}", f"Citations: {cites}"]
+        if venue:
+            meta.append(f"Venue: {venue}")
+        if aid:
+            meta.append(f"arxiv_id: {aid}")
+        lines.append(" | ".join(meta))
+        if aid:
+            lines.append(f"https://arxiv.org/abs/{aid}")
+        if tldr:
+            lines.append(f"**TL;DR:** {tldr}")
+        lines.append("")
+
+    lines.append("Use paper_details with arxiv_id for full info, or read_paper to read sections.")
+    return "\n".join(lines)
+
+
+async def _s2_bulk_search(query: str, args: dict[str, Any], limit: int) -> ToolResult | None:
+    """Search via S2 bulk endpoint with filters. Returns None on failure."""
+    params: dict[str, Any] = {
+        "query": query,
+        "limit": limit,
+        "fields": "title,externalIds,year,citationCount,venue,publicationDate",
+    }
+
+    # Date filter
+    date_from = args.get("date_from", "")
+    date_to = args.get("date_to", "")
+    if date_from or date_to:
+        params["publicationDateOrYear"] = f"{date_from}:{date_to}"
+
+    # Fields of study
+    categories = args.get("categories")
+    if categories:
+        params["fieldsOfStudy"] = categories
+
+    # Min citations
+    min_cites = args.get("min_citations")
+    if min_cites:
+        params["minCitationCount"] = str(min_cites)
+
+    # Sort
+    sort_by = args.get("sort_by")
+    if sort_by and sort_by != "relevance":
+        params["sort"] = f"{sort_by}:desc"
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await _s2_request(client, "GET", "/graph/v1/paper/search/bulk", params=params)
+        if not resp or resp.status_code != 200:
+            return None
+        data = resp.json()
+
+    papers = data.get("data") or []
+    if not papers:
+        return {
+            "formatted": f"No papers found for '{query}' with the given filters.",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    formatted = _format_s2_paper_list(papers[:limit], f"Papers matching '{query}' (Semantic Scholar)")
+    return {
+        "formatted": formatted,
+        "totalResults": data.get("total", len(papers)),
+        "resultsShared": min(limit, len(papers)),
+    }
+
+
+async def _op_search(args: dict[str, Any], limit: int) -> ToolResult:
+    query = args.get("query")
+    if not query:
+        return _error("'query' is required for search operation.")
+
+    # Always try Semantic Scholar first — it covers all academic fields.
+    # HF papers search is ML-only and misses biology, chemistry, physics, etc.
+    result = await _s2_bulk_search(query, args, limit)
+    if result is not None and result.get("totalResults", 0) > 0:
+        return result
+
+    # Fall back to HF search if S2 returned nothing
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(
+            f"{HF_API}/papers/search", params={"q": query, "limit": limit}
+        )
+        resp.raise_for_status()
+        papers = resp.json()
+
+    if not papers:
+        return {
+            "formatted": f"No papers found for '{query}'",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    formatted = _format_paper_list(papers, f"Papers matching '{query}'")
+    return {
+        "formatted": formatted,
+        "totalResults": len(papers),
+        "resultsShared": len(papers),
+    }
+
+
+async def _op_paper_details(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for paper_details.")
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(f"{HF_API}/papers/{arxiv_id}")
+        resp.raise_for_status()
+        paper = resp.json()
+
+    return {
+        "formatted": _format_paper_detail(paper),
+        "totalResults": 1,
+        "resultsShared": 1,
+    }
+
+
+async def _op_read_paper(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for read_paper.")
+
+    section_query = args.get("section")
+
+    # Try fetching HTML from arxiv, then ar5iv, then fallback to abstract
+    parsed = None
+    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+        for base_url in [ARXIV_HTML, AR5IV_HTML]:
+            try:
+                resp = await client.get(f"{base_url}/{arxiv_id}")
+                if resp.status_code == 200:
+                    parsed = _parse_paper_html(resp.text)
+                    if parsed["sections"]:  # Only use if we got real sections
+                        break
+                    parsed = None
+            except httpx.RequestError:
+                continue
+
+    # Fallback: return abstract from HF API
+    if not parsed or not parsed["sections"]:
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.get(f"{HF_API}/papers/{arxiv_id}")
+                resp.raise_for_status()
+                paper = resp.json()
+            abstract = paper.get("summary", "")
+            title = paper.get("title", "")
+            msg = f"# {title}\nhttps://arxiv.org/abs/{arxiv_id}\n\n"
+            msg += f"## Abstract\n{abstract}\n\n"
+            msg += "HTML version not available for this paper. Only abstract shown.\n"
+            msg += f"PDF: https://arxiv.org/pdf/{arxiv_id}"
+            return {"formatted": msg, "totalResults": 1, "resultsShared": 1}
+        except Exception:
+            return _error(
+                f"Could not fetch paper {arxiv_id}. Check the arxiv ID is correct."
+            )
+
+    # Return TOC or specific section
+    if not section_query:
+        formatted = _format_read_paper_toc(parsed, arxiv_id)
+        return {
+            "formatted": formatted,
+            "totalResults": len(parsed["sections"]),
+            "resultsShared": len(parsed["sections"]),
+        }
+
+    section = _find_section(parsed["sections"], section_query)
+    if not section:
+        available = "\n".join(f"- {s['title']}" for s in parsed["sections"])
+        return _error(
+            f"Section '{section_query}' not found. Available sections:\n{available}"
+        )
+
+    formatted = _format_read_paper_section(section, arxiv_id)
+    return {"formatted": formatted, "totalResults": 1, "resultsShared": 1}
+
+
+# ---------------------------------------------------------------------------
+# Citation graph (Semantic Scholar)
+# ---------------------------------------------------------------------------
+
+
+def _format_citation_entry(entry: dict, show_context: bool = False) -> str:
+    """Format a single citation/reference entry."""
+    paper = entry.get("citingPaper") or entry.get("citedPaper") or {}
+    title = paper.get("title") or "(untitled)"
+    year = paper.get("year") or "?"
+    cites = paper.get("citationCount", 0)
+    ext_ids = paper.get("externalIds") or {}
+    aid = ext_ids.get("ArXiv", "")
+    influential = " **[influential]**" if entry.get("isInfluential") else ""
+
+    parts = [f"- **{title}** ({year}, {cites} cites){influential}"]
+    if aid:
+        parts[0] += f"  arxiv:{aid}"
+
+    if show_context:
+        intents = entry.get("intents") or []
+        if intents:
+            parts.append(f"  Intent: {', '.join(intents)}")
+        contexts = entry.get("contexts") or []
+        for ctx in contexts[:2]:
+            if ctx:
+                parts.append(f"  > {_truncate(ctx, 200)}")
+
+    return "\n".join(parts)
+
+
+def _format_citation_graph(
+    arxiv_id: str,
+    references: list[dict] | None,
+    citations: list[dict] | None,
+) -> str:
+    lines = [f"# Citation Graph for {arxiv_id}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+
+    if references is not None:
+        lines.append(f"## References ({len(references)})")
+        if references:
+            for entry in references:
+                lines.append(_format_citation_entry(entry))
+        else:
+            lines.append("No references found.")
+        lines.append("")
+
+    if citations is not None:
+        lines.append(f"## Citations ({len(citations)})")
+        if citations:
+            for entry in citations:
+                lines.append(_format_citation_entry(entry, show_context=True))
+        else:
+            lines.append("No citations found.")
+        lines.append("")
+
+    lines.append("**Tip:** Use paper_details with an arxiv_id from above to explore further.")
+    return "\n".join(lines)
+
+
+async def _op_citation_graph(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for citation_graph.")
+
+    direction = args.get("direction", "both")
+    s2_id = _s2_paper_id(arxiv_id)
+    fields = "title,externalIds,year,citationCount,influentialCitationCount,contexts,intents,isInfluential"
+    params = {"fields": fields, "limit": limit}
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        refs, cites = None, None
+        coros = []
+        if direction in ("references", "both"):
+            coros.append(_s2_get_json(client, f"/graph/v1/paper/{s2_id}/references", params))
+        if direction in ("citations", "both"):
+            coros.append(_s2_get_json(client, f"/graph/v1/paper/{s2_id}/citations", params))
+
+        results = await asyncio.gather(*coros, return_exceptions=True)
+        idx = 0
+        if direction in ("references", "both"):
+            r = results[idx]
+            if isinstance(r, dict):
+                refs = r.get("data", [])
+            idx += 1
+        if direction in ("citations", "both"):
+            r = results[idx]
+            if isinstance(r, dict):
+                cites = r.get("data", [])
+
+    if refs is None and cites is None:
+        return _error(f"Could not fetch citation data for {arxiv_id}. Paper may not be indexed by Semantic Scholar.")
+
+    total = (len(refs) if refs else 0) + (len(cites) if cites else 0)
+    return {
+        "formatted": _format_citation_graph(arxiv_id, refs, cites),
+        "totalResults": total,
+        "resultsShared": total,
+    }
+
+
+async def _op_find_datasets(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for find_datasets.")
+
+    sort = args.get("sort", "downloads")
+    sort_key = SORT_MAP.get(sort, "downloads")
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(
+            f"{HF_API}/datasets",
+            params={
+                "filter": f"arxiv:{arxiv_id}",
+                "limit": limit,
+                "sort": sort_key,
+                "direction": -1,
+            },
+        )
+        resp.raise_for_status()
+        datasets = resp.json()
+
+    if not datasets:
+        return {
+            "formatted": f"No datasets found linked to paper {arxiv_id}.\nhttps://huggingface.co/papers/{arxiv_id}",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    return {
+        "formatted": _format_datasets(datasets, arxiv_id, sort),
+        "totalResults": len(datasets),
+        "resultsShared": len(datasets),
+    }
+
+
+async def _op_find_models(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for find_models.")
+
+    sort = args.get("sort", "downloads")
+    sort_key = SORT_MAP.get(sort, "downloads")
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(
+            f"{HF_API}/models",
+            params={
+                "filter": f"arxiv:{arxiv_id}",
+                "limit": limit,
+                "sort": sort_key,
+                "direction": -1,
+            },
+        )
+        resp.raise_for_status()
+        models = resp.json()
+
+    if not models:
+        return {
+            "formatted": f"No models found linked to paper {arxiv_id}.\nhttps://huggingface.co/papers/{arxiv_id}",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    return {
+        "formatted": _format_models(models, arxiv_id, sort),
+        "totalResults": len(models),
+        "resultsShared": len(models),
+    }
+
+
+async def _op_find_collections(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for find_collections.")
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(f"{HF_API}/collections", params={"paper": arxiv_id})
+        resp.raise_for_status()
+        collections = resp.json()
+
+    if not collections:
+        return {
+            "formatted": f"No collections found containing paper {arxiv_id}.\nhttps://huggingface.co/papers/{arxiv_id}",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    collections = collections[:limit]
+    return {
+        "formatted": _format_collections(collections, arxiv_id),
+        "totalResults": len(collections),
+        "resultsShared": len(collections),
+    }
+
+
+async def _op_find_all_resources(args: dict[str, Any], limit: int) -> ToolResult:
+    arxiv_id = _validate_arxiv_id(args)
+    if not arxiv_id:
+        return _error("'arxiv_id' is required for find_all_resources.")
+
+    per_cat = min(limit, 10)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        results = await asyncio.gather(
+            client.get(
+                f"{HF_API}/datasets",
+                params={
+                    "filter": f"arxiv:{arxiv_id}",
+                    "limit": per_cat,
+                    "sort": "downloads",
+                    "direction": -1,
+                },
+            ),
+            client.get(
+                f"{HF_API}/models",
+                params={
+                    "filter": f"arxiv:{arxiv_id}",
+                    "limit": per_cat,
+                    "sort": "downloads",
+                    "direction": -1,
+                },
+            ),
+            client.get(f"{HF_API}/collections", params={"paper": arxiv_id}),
+            return_exceptions=True,
+        )
+
+    sections = []
+    total = 0
+
+    # Datasets
+    if isinstance(results[0], Exception):
+        sections.append(f"## Datasets\nError: {results[0]}")
+    else:
+        datasets = results[0].json()
+        total += len(datasets)
+        sections.append(_format_datasets_compact(datasets[:per_cat]))
+
+    # Models
+    if isinstance(results[1], Exception):
+        sections.append(f"## Models\nError: {results[1]}")
+    else:
+        models = results[1].json()
+        total += len(models)
+        sections.append(_format_models_compact(models[:per_cat]))
+
+    # Collections
+    if isinstance(results[2], Exception):
+        sections.append(f"## Collections\nError: {results[2]}")
+    else:
+        collections = results[2].json()
+        total += len(collections)
+        sections.append(_format_collections_compact(collections[:per_cat]))
+
+    header = f"# Resources linked to paper {arxiv_id}\nhttps://huggingface.co/papers/{arxiv_id}\n"
+    formatted = header + "\n\n".join(sections)
+    return {"formatted": formatted, "totalResults": total, "resultsShared": total}
+
+
+# ---------------------------------------------------------------------------
+# Snippet search (Semantic Scholar)
+# ---------------------------------------------------------------------------
+
+
+def _format_snippets(snippets: list[dict], query: str) -> str:
+    lines = [f"# Snippet Search: '{query}'"]
+    lines.append(f"Found {len(snippets)} matching passage(s)\n")
+
+    for i, item in enumerate(snippets, 1):
+        paper = item.get("paper") or {}
+        ptitle = paper.get("title") or "(untitled)"
+        year = paper.get("year") or "?"
+        cites = paper.get("citationCount", 0)
+        ext_ids = paper.get("externalIds") or {}
+        aid = ext_ids.get("ArXiv", "")
+
+        snippet = item.get("snippet") or {}
+        text = snippet.get("text", "")
+        section = snippet.get("section") or ""
+
+        lines.append(f"### {i}. {ptitle} ({year}, {cites} cites)")
+        if aid:
+            lines.append(f"arxiv:{aid}")
+        if section:
+            lines.append(f"Section: {section}")
+        if text:
+            lines.append(f"> {_truncate(text, 400)}")
+        lines.append("")
+
+    lines.append("Use paper_details or read_paper with arxiv_id to explore a paper further.")
+    return "\n".join(lines)
+
+
+async def _op_snippet_search(args: dict[str, Any], limit: int) -> ToolResult:
+    query = args.get("query")
+    if not query:
+        return _error("'query' is required for snippet_search.")
+
+    params: dict[str, Any] = {
+        "query": query,
+        "limit": limit,
+        "fields": "title,externalIds,year,citationCount",
+    }
+
+    # Optional filters (same as search)
+    date_from = args.get("date_from", "")
+    date_to = args.get("date_to", "")
+    if date_from or date_to:
+        params["publicationDateOrYear"] = f"{date_from}:{date_to}"
+    if args.get("categories"):
+        params["fieldsOfStudy"] = args["categories"]
+    if args.get("min_citations"):
+        params["minCitationCount"] = str(args["min_citations"])
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await _s2_request(client, "GET", "/graph/v1/snippet/search", params=params)
+        if not resp or resp.status_code != 200:
+            # Snippet endpoint is rate-limited without an API key.
+            # Fall back to a regular search so the agent still gets results.
+            return await _op_search(args, limit)
+        data = resp.json()
+
+    snippets = data.get("data") or []
+    if not snippets:
+        return {
+            "formatted": f"No snippets found for '{query}'.",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    return {
+        "formatted": _format_snippets(snippets, query),
+        "totalResults": len(snippets),
+        "resultsShared": len(snippets),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Recommendations (Semantic Scholar)
+# ---------------------------------------------------------------------------
+
+
+async def _op_recommend(args: dict[str, Any], limit: int) -> ToolResult:
+    positive_ids = args.get("positive_ids")
+    arxiv_id = _validate_arxiv_id(args)
+
+    if not arxiv_id and not positive_ids:
+        return _error("'arxiv_id' or 'positive_ids' is required for recommend.")
+
+    fields = "title,externalIds,year,citationCount,tldr,venue"
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        if positive_ids and not arxiv_id:
+            # Multi-paper recommendations (POST, not cached)
+            pos = [_s2_paper_id(pid.strip()) for pid in positive_ids.split(",") if pid.strip()]
+            neg_raw = args.get("negative_ids", "")
+            neg = [_s2_paper_id(pid.strip()) for pid in neg_raw.split(",") if pid.strip()] if neg_raw else []
+            resp = await _s2_request(
+                client, "POST", "/recommendations/v1/papers/",
+                json={"positivePaperIds": pos, "negativePaperIds": neg},
+                params={"fields": fields, "limit": limit},
+            )
+            if not resp or resp.status_code != 200:
+                return _error("Recommendation request failed. Semantic Scholar may be unavailable.")
+            data = resp.json()
+        else:
+            # Single-paper recommendations (cached)
+            data = await _s2_get_json(
+                client,
+                f"/recommendations/v1/papers/forpaper/{_s2_paper_id(arxiv_id)}",
+                {"fields": fields, "limit": limit, "from": "recent"},
+            )
+            if not data:
+                return _error("Recommendation request failed. Semantic Scholar may be unavailable.")
+
+    papers = data.get("recommendedPapers") or []
+    if not papers:
+        return {
+            "formatted": "No recommendations found.",
+            "totalResults": 0,
+            "resultsShared": 0,
+        }
+
+    title = f"Recommended papers based on {arxiv_id or positive_ids}"
+    return {
+        "formatted": _format_s2_paper_list(papers[:limit], title),
+        "totalResults": len(papers),
+        "resultsShared": min(limit, len(papers)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Operation dispatch
+# ---------------------------------------------------------------------------
+
+_OPERATIONS = {
+    "trending": _op_trending,
+    "search": _op_search,
+    "paper_details": _op_paper_details,
+    "read_paper": _op_read_paper,
+    "citation_graph": _op_citation_graph,
+    "snippet_search": _op_snippet_search,
+    "recommend": _op_recommend,
+    "find_datasets": _op_find_datasets,
+    "find_models": _op_find_models,
+    "find_collections": _op_find_collections,
+    "find_all_resources": _op_find_all_resources,
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool spec + handler
+# ---------------------------------------------------------------------------
+
+RESEARCH_PAPERS_TOOL_SPEC = {
+    "name": "research_papers",
+    "description": (
+        "Discover ML research papers, analyze citations, search paper contents, and find linked resources.\n\n"
+        "Combines HuggingFace Hub, arXiv, and Semantic Scholar. Use for exploring research areas, "
+        "finding datasets for a task, tracing citation chains, or implementing a paper's approach.\n\n"
+        "Typical flows:\n"
+        "  search → read_paper → find_all_resources → hf_inspect_dataset\n"
+        "  search → paper_details → citation_graph → read_paper (trace influence)\n"
+        "  snippet_search → paper_details → read_paper (find specific claims)\n\n"
+        "Operations:\n"
+        "- trending: Get trending daily papers, optionally filter by topic keyword\n"
+        "- search: Search papers. Uses HF by default (ML-tuned). Add date_from/min_citations/categories to use Semantic Scholar with filters\n"
+        "- paper_details: Metadata, abstract, AI summary, github link\n"
+        "- read_paper: Read paper contents — without section: abstract + TOC; with section: full text\n"
+        "- citation_graph: Get references and citations for a paper with influence flags and citation intents\n"
+        "- snippet_search: Semantic search over full-text passages from 12M+ papers\n"
+        "- recommend: Find similar papers (single paper or positive/negative examples)\n"
+        "- find_datasets: Find datasets linked to a paper\n"
+        "- find_models: Find models linked to a paper\n"
+        "- find_collections: Find collections that include a paper\n"
+        "- find_all_resources: Parallel fetch of datasets + models + collections for a paper"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "operation": {
+                "type": "string",
+                "enum": list(_OPERATIONS.keys()),
+                "description": "Operation to execute.",
+            },
+            "query": {
+                "type": "string",
+                "description": (
+                    "Search query. Required for: search, snippet_search. "
+                    "Optional for: trending (filters by keyword). "
+                    "Supports boolean syntax for Semantic Scholar: '\"exact phrase\" term1 | term2'."
+                ),
+            },
+            "arxiv_id": {
+                "type": "string",
+                "description": (
+                    "ArXiv paper ID (e.g. '2305.18290'). "
+                    "Required for: paper_details, read_paper, citation_graph, find_datasets, find_models, find_collections, find_all_resources. "
+                    "Optional for: recommend (single-paper recs). Get IDs from search results first."
+                ),
+            },
+            "section": {
+                "type": "string",
+                "description": (
+                    "Section name or number to read (e.g. '3', 'Experiments', '4.2'). "
+                    "Optional for: read_paper. Without this, returns abstract + TOC."
+                ),
+            },
+            "direction": {
+                "type": "string",
+                "enum": ["citations", "references", "both"],
+                "description": "Direction for citation_graph. Default: both.",
+            },
+            "date": {
+                "type": "string",
+                "description": "Date in YYYY-MM-DD format. Optional for: trending (defaults to recent papers).",
+            },
+            "date_from": {
+                "type": "string",
+                "description": "Start date (YYYY-MM-DD). Triggers Semantic Scholar search. For: search, snippet_search.",
+            },
+            "date_to": {
+                "type": "string",
+                "description": "End date (YYYY-MM-DD). Triggers Semantic Scholar search. For: search, snippet_search.",
+            },
+            "categories": {
+                "type": "string",
+                "description": "Field of study filter (e.g. 'Computer Science'). Triggers Semantic Scholar search.",
+            },
+            "min_citations": {
+                "type": "integer",
+                "description": "Minimum citation count filter. Triggers Semantic Scholar search.",
+            },
+            "sort_by": {
+                "type": "string",
+                "enum": ["relevance", "citationCount", "publicationDate"],
+                "description": "Sort order for Semantic Scholar search. Default: relevance.",
+            },
+            "positive_ids": {
+                "type": "string",
+                "description": "Comma-separated arxiv IDs for multi-paper recommendations. For: recommend.",
+            },
+            "negative_ids": {
+                "type": "string",
+                "description": "Comma-separated arxiv IDs as negative examples. For: recommend.",
+            },
+            "sort": {
+                "type": "string",
+                "enum": ["downloads", "likes", "trending"],
+                "description": (
+                    "Sort order for find_datasets and find_models. Default: downloads."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results to return (default: 10, max: 50).",
+            },
+        },
+        "required": ["operation"],
+    },
+}
+
+
+async def research_papers_handler(arguments: dict[str, Any]) -> tuple[str, bool]:
+    """Handler for agent tool router."""
+    operation = arguments.get("operation")
+    if not operation:
+        return "'operation' parameter is required.", False
+
+    handler = _OPERATIONS.get(operation)
+    if not handler:
+        valid = ", ".join(_OPERATIONS.keys())
+        return f"Unknown operation: '{operation}'. Valid: {valid}", False
+
+    limit = min(arguments.get("limit", DEFAULT_LIMIT), MAX_LIMIT)
+
+    try:
+        result = await handler(arguments, limit)
+        return result["formatted"], not result.get("isError", False)
+    except httpx.HTTPStatusError as e:
+        return f"API error: {e.response.status_code} — {e.response.text[:200]}", False
+    except httpx.RequestError as e:
+        return f"Request error: {e}", False
+    except Exception as e:
+        return f"Error in {operation}: {e}", False
+
+
+# Backwards-compatible alias (older prompts/configs)
+HF_PAPERS_TOOL_SPEC = RESEARCH_PAPERS_TOOL_SPEC
+hf_papers_handler = research_papers_handler

--- a/skydiscover/llm/tools/run_command_tool.py
+++ b/skydiscover/llm/tools/run_command_tool.py
@@ -1,0 +1,329 @@
+"""run_command tool – execute a sandboxed shell command inside the codebase root.
+
+The agent calls this tool with a shell command string.  The tool:
+  1. Validates the command against a safety allowlist.
+  2. Runs it as a subprocess with a hard wall-clock timeout.
+  3. Captures stdout + stderr and returns them as text (truncated if huge).
+
+Design goals
+------------
+* Useful for data exploration: ``python script.py``, ``head -n 50 data.csv``,
+  ``wc -l *.py``, ``cat results.json``, etc.
+* NOT a general shell: destructive or network commands are blocked.
+* CWD is always pinned to ``codebase_root``; absolute paths outside it are
+  also blocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shlex
+import subprocess
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Safety configuration
+# ---------------------------------------------------------------------------
+
+# Maximum wall-clock seconds the subprocess may run (default; can be overridden by config/tool args).
+DEFAULT_TIMEOUT = 100
+
+# Maximum characters of combined stdout+stderr returned to the agent (default; can be overridden by config).
+DEFAULT_MAX_OUTPUT_CHARS = 20_000
+
+# Executables that are explicitly allowed.  Anything not in this set is
+# rejected so the agent cannot run ``rm``, ``curl``, ``wget``, etc.
+_ALLOWED_EXECUTABLES: frozenset[str] = frozenset(
+    {
+        # Python
+        "python",
+        "python3",
+        "python3.10",
+        "python3.11",
+        "python3.12",
+        # Data inspection
+        "cat",
+        "head",
+        "tail",
+        "less",
+        "more",
+        "wc",
+        "grep",
+        "egrep",
+        "fgrep",
+        "rg",          # ripgrep
+        "find",
+        "ls",
+        "du",
+        "df",
+        "stat",
+        # Text processing
+        "sort",
+        "uniq",
+        "cut",
+        "awk",
+        "sed",
+        "tr",
+        "paste",
+        "join",
+        "diff",
+        "comm",
+        "xxd",
+        "jq",
+        # Computation / data science helpers
+        "Rscript",
+        "julia",
+        "node",
+        # Archive inspection (read-only)
+        "tar",
+        "unzip",
+        "zipinfo",
+        # Misc safe read-only tools
+        "echo",
+        "printf",
+        "date",
+        "whoami",
+        "uname",
+        "env",
+        "pwd",
+    }
+)
+
+# These substrings in the raw command string are unconditionally blocked
+# regardless of the executable, to prevent shell injection via pipes /
+# redirection that write outside the sandbox.
+# Shell metacharacters — only dangerous in shell=True mode (unsafe).
+# With shell=False these are harmless characters in argv strings.
+_SHELL_PATTERNS: list[re.Pattern] = [
+    re.compile(r"[|&;`]"),
+    re.compile(r"\$[({]"),
+    re.compile(r">{1,2}"),
+    re.compile(r"<\("),
+]
+
+# Destructive / network executables — blocked in both modes.
+_BLOCKED_EXECUTABLES: list[re.Pattern] = [
+    re.compile(r"\brm\b"),
+    re.compile(r"\bchmod\b"),
+    re.compile(r"\bchown\b"),
+    re.compile(r"\bsudo\b"),
+    re.compile(r"\bsu\b"),
+    re.compile(r"\bcurl\b"),
+    re.compile(r"\bwget\b"),
+    re.compile(r"\bscp\b"),
+    re.compile(r"\brsync\b"),
+    re.compile(r"\bssh\b"),
+    re.compile(r"\bnc\b"),
+    re.compile(r"\bkill\b"),
+    re.compile(r"\bpkill\b"),
+    re.compile(r"\bmv\b"),
+    re.compile(r"\bcp\b"),
+    re.compile(r"\bdd\b"),
+    re.compile(r"\bmkdir\b"),
+    re.compile(r"\brmdir\b"),
+    re.compile(r"\btouch\b"),
+    re.compile(r"\bln\b"),
+    re.compile(r"\binstall\b"),
+    re.compile(r"\bapt\b"),
+    re.compile(r"\bpip\b"),
+    re.compile(r"\bnpm\b"),
+    re.compile(r"\bconda\b"),
+]
+
+
+def _check_command_safety(command: str, *, unsafe: bool = False) -> str | None:
+    """Return an error string if *command* is unsafe, else None."""
+    # Shell metacharacters only matter when running via shell=True.
+    # With shell=False, subprocess passes argv directly — no redirects/pipes.
+    if unsafe:
+        for pat in _SHELL_PATTERNS:
+            if pat.search(command):
+                return (
+                    f"Command blocked: contains forbidden pattern '{pat.pattern}'. "
+                    "Only read-only, non-network commands without shell operators are allowed."
+                )
+
+    # Parse the first token as the executable name.
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        return f"Could not parse command: {exc}"
+
+    if not tokens:
+        return "Empty command."
+
+    exe = os.path.basename(tokens[0])
+
+    # Destructive / network executables are blocked regardless of mode.
+    for pat in _BLOCKED_EXECUTABLES:
+        if pat.fullmatch(exe):
+            return (
+                f"Command blocked: '{exe}' is not allowed. "
+                "Only read-only, non-network commands are allowed."
+            )
+
+    if exe not in _ALLOWED_EXECUTABLES:
+        allowed_sorted = ", ".join(sorted(_ALLOWED_EXECUTABLES))
+        return (
+            f"Executable '{exe}' is not in the allowed list. "
+            f"Allowed executables: {allowed_sorted}"
+        )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core execution logic
+# ---------------------------------------------------------------------------
+
+
+def _default_shell_executable() -> str | None:
+    """Pick a reasonable shell executable for shell=True mode."""
+    for candidate in ("/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"):
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def run_command_sync(
+    command: str,
+    codebase_root: str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+    max_output_chars: int = DEFAULT_MAX_OUTPUT_CHARS,
+    unsafe: bool = False,
+) -> dict[str, Any]:
+    """Run *command* synchronously.
+
+    Returns a dict with keys:
+      stdout      – captured stdout (str)
+      stderr      – captured stderr (str)
+      returncode  – process exit code (int)
+      truncated   – True if output was trimmed (bool)
+      error       – set only on OS-level failure (str)
+    """
+    try:
+        if unsafe:
+            result = subprocess.run(
+                command,
+                cwd=codebase_root,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                shell=True,
+                executable=_default_shell_executable(),
+            )
+        else:
+            tokens = shlex.split(command)
+            result = subprocess.run(
+                tokens,
+                cwd=codebase_root,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                # Intentionally NO shell=True – avoids shell injection.
+            )
+    except subprocess.TimeoutExpired:
+        return {"error": f"Command timed out after {timeout}s.", "returncode": -1}
+    except FileNotFoundError as exc:
+        return {"error": f"Executable not found: {exc}", "returncode": -1}
+    except OSError as exc:
+        return {"error": f"OS error running command: {exc}", "returncode": -1}
+
+    combined = ""
+    if result.stdout:
+        combined += result.stdout
+    if result.stderr:
+        combined += "\n[stderr]\n" + result.stderr
+
+    truncated = False
+    if len(combined) > max_output_chars:
+        half = max_output_chars // 2
+        combined = (
+            combined[:half]
+            + f"\n\n... ({len(combined) - max_output_chars} chars truncated) ...\n\n"
+            + combined[-half:]
+        )
+        truncated = True
+
+    return {
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "combined": combined,
+        "returncode": result.returncode,
+        "truncated": truncated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Async handler (called from agentic_generator._run_tool)
+# ---------------------------------------------------------------------------
+
+
+async def run_command_handler(
+    arguments: dict[str, Any],
+    codebase_root: str,
+    run_command_default_timeout: int = DEFAULT_TIMEOUT,
+    run_command_max_timeout: int = 120,
+    run_command_max_output_chars: int = DEFAULT_MAX_OUTPUT_CHARS,
+    allow_unsafe_commands: bool = False,
+    **_kw: Any,
+) -> tuple[str, bool]:
+    """Async handler called by the agentic loop."""
+    command = arguments.get("command", "").strip()
+    requested_timeout = arguments.get("timeout", run_command_default_timeout)
+    timeout = int(requested_timeout)
+    timeout = max(1, min(timeout, int(run_command_max_timeout)))  # clamp
+    max_output_chars = int(run_command_max_output_chars)
+    max_output_chars = max(1_000, min(max_output_chars, 500_000))
+    unsafe = bool(arguments.get("unsafe", False))
+
+    if not command:
+        return "Error: run_command requires a 'command' argument.", False
+    if not codebase_root:
+        return "Error: codebase_root not configured.", False
+
+    # Safety check (skipped only in explicit unsafe mode)
+    if unsafe and not allow_unsafe_commands:
+        return (
+            "Error: unsafe=true was requested but agentic.allow_unsafe_commands is disabled.",
+            False,
+        )
+    if not unsafe:
+        safety_err = _check_command_safety(command)
+        if safety_err:
+            return f"Error: {safety_err}", False
+
+    logger.info("run_command: executing %r in %s (timeout=%ds)", command, codebase_root, timeout)
+
+    result = await asyncio.to_thread(
+        run_command_sync,
+        command,
+        codebase_root,
+        timeout=timeout,
+        max_output_chars=max_output_chars,
+        unsafe=unsafe,
+    )
+
+    if "error" in result:
+        return f"Error running command: {result['error']}", False
+
+    rc = result["returncode"]
+    output = result["combined"] or "(no output)"
+    trunc_note = "\n[Output was truncated]" if result.get("truncated") else ""
+
+    mode = "shell" if unsafe else "exec"
+    msg = (
+        f"$ {command}\n"
+        f"[mode: {mode}]\n"
+        f"[exit code: {rc}]\n\n"
+        f"{output}"
+        f"{trunc_note}"
+    )
+    success = rc == 0
+    return msg, success

--- a/skydiscover/llm/tools/web_search_tool.py
+++ b/skydiscover/llm/tools/web_search_tool.py
@@ -1,0 +1,420 @@
+"""DuckDuckGo HTML web search tool.
+
+This mirrors Claw Code's Rust WebSearch behavior: fetch DuckDuckGo's HTML
+endpoint, extract result links, optionally filter domains, and return a
+JSON payload the model can cite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import parse_qsl, parse_qs, urlencode, urlparse, urlunparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SEARCH_URL = "https://html.duckduckgo.com/html/"
+WEB_SEARCH_BASE_URL_ENV = "CLAWD_WEB_SEARCH_BASE_URL"
+AUTO_FETCH_COUNT = 3
+AUTO_FETCH_PREVIEW_CHARS = 3000
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+REQUEST_TIMEOUT_SECONDS = 20
+MAX_RESULTS = 8
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    title: str
+    url: str
+
+    def as_json(self) -> dict[str, str]:
+        return {"title": self.title, "url": self.url}
+
+
+class _AnchorParser(HTMLParser):
+    def __init__(self, *, require_result_class: bool) -> None:
+        super().__init__(convert_charrefs=True)
+        self.require_result_class = require_result_class
+        self.hits: list[tuple[str, str]] = []
+        self._active_href: str | None = None
+        self._active_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        attr_map = {key.lower(): value or "" for key, value in attrs}
+        href = attr_map.get("href")
+        if not href:
+            return
+        if self.require_result_class and "result__a" not in attr_map.get("class", ""):
+            return
+        self._active_href = href
+        self._active_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._active_href is not None:
+            self._active_text.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        if self._active_href is not None:
+            self._active_text.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if self._active_href is not None:
+            self._active_text.append(f"&#{name};")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() != "a" or self._active_href is None:
+            return
+        title = collapse_whitespace(html.unescape("".join(self._active_text))).strip()
+        self.hits.append((self._active_href, title))
+        self._active_href = None
+        self._active_text = []
+
+
+def build_search_url(query: str) -> str:
+    base = os.environ.get(WEB_SEARCH_BASE_URL_ENV, DEFAULT_SEARCH_URL)
+    parsed = urlparse(base)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"invalid search base URL: {base}")
+
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    query_pairs.append(("q", query))
+    return urlunparse(parsed._replace(query=urlencode(query_pairs)))
+
+
+def collapse_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
+def decode_duckduckgo_redirect(url: str) -> str | None:
+    if url.startswith("http://") or url.startswith("https://"):
+        return html.unescape(url)
+    if url.startswith("//"):
+        joined = f"https:{url}"
+    elif url.startswith("/"):
+        joined = f"https://duckduckgo.com{url}"
+    else:
+        return None
+
+    parsed = urlparse(joined)
+    if parsed.path in {"/l", "/l/"}:
+        uddg = parse_qs(parsed.query).get("uddg", [])
+        if uddg:
+            return html.unescape(uddg[0])
+    return joined
+
+
+def _extract_links(search_html: str, *, require_result_class: bool) -> list[SearchHit]:
+    parser = _AnchorParser(require_result_class=require_result_class)
+    parser.feed(search_html)
+
+    hits: list[SearchHit] = []
+    for raw_url, title in parser.hits:
+        if not title:
+            continue
+        decoded_url = decode_duckduckgo_redirect(raw_url)
+        if decoded_url and (
+            decoded_url.startswith("http://") or decoded_url.startswith("https://")
+        ):
+            hits.append(SearchHit(title=title, url=decoded_url))
+    return hits
+
+
+def extract_search_hits(search_html: str) -> list[SearchHit]:
+    return _extract_links(search_html, require_result_class=True)
+
+
+def extract_search_hits_from_generic_links(search_html: str) -> list[SearchHit]:
+    return _extract_links(search_html, require_result_class=False)
+
+
+def normalize_domain_filter(domain: str) -> str:
+    trimmed = domain.strip()
+    parsed = urlparse(trimmed)
+    candidate = parsed.hostname if parsed.scheme and parsed.hostname else trimmed
+    return candidate.strip().lstrip(".").rstrip("/").lower()
+
+
+def host_matches_list(url: str, domains: list[str]) -> bool:
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    normalized_host = host.lower()
+    for domain in domains:
+        normalized = normalize_domain_filter(domain)
+        if normalized and (
+            normalized_host == normalized or normalized_host.endswith(f".{normalized}")
+        ):
+            return True
+    return False
+
+
+def dedupe_hits(hits: list[SearchHit]) -> list[SearchHit]:
+    seen: set[str] = set()
+    deduped: list[SearchHit] = []
+    for hit in hits:
+        if hit.url in seen:
+            continue
+        seen.add(hit.url)
+        deduped.append(hit)
+    return deduped
+
+
+_SKIP_URL_PATTERNS = ("duckduckgo.com/y.js", "duckduckgo.com/l/")
+
+
+def _is_fetchable_hit(hit: SearchHit) -> bool:
+    """Skip ad redirects and non-content URLs."""
+    return not any(pat in hit.url for pat in _SKIP_URL_PATTERNS)
+
+
+def _robust_html_to_text(raw_html: str) -> str:
+    """Extract text from HTML, with a regex fallback for stubborn pages."""
+    from skydiscover.llm.tools.fetch_webpage_tool import html_to_text
+
+    text = html_to_text(raw_html)
+    if len(text.strip()) >= 100:
+        return text
+    # Fallback: strip tags with regex, collapse whitespace
+    stripped = re.sub(r"<script[^>]*>.*?</script>", " ", raw_html, flags=re.DOTALL | re.IGNORECASE)
+    stripped = re.sub(r"<style[^>]*>.*?</style>", " ", stripped, flags=re.DOTALL | re.IGNORECASE)
+    stripped = re.sub(r"<[^>]+>", " ", stripped)
+    stripped = html.unescape(stripped)
+    stripped = re.sub(r"\s+", " ", stripped).strip()
+    return stripped
+
+
+def _auto_fetch_top_hits(
+    hits: list[SearchHit],
+    max_fetch: int = AUTO_FETCH_COUNT,
+    max_chars: int = AUTO_FETCH_PREVIEW_CHARS,
+) -> str:
+    """Fetch the top search result pages and return truncated text previews."""
+    fetchable = [h for h in hits if _is_fetchable_hit(h)]
+    previews: list[str] = []
+    for hit in fetchable:
+        if len(previews) >= max_fetch:
+            break
+        try:
+            resp = requests.get(
+                hit.url,
+                headers={"User-Agent": USER_AGENT},
+                timeout=15,
+                allow_redirects=True,
+            )
+            if resp.status_code != 200:
+                continue
+            content_type = resp.headers.get("Content-Type", "")
+            if "pdf" in content_type or "octet-stream" in content_type:
+                continue
+            if "html" in content_type or not content_type:
+                text = _robust_html_to_text(resp.text)
+            else:
+                text = resp.text
+            text = text.strip()
+            if len(text) < 200 or "captcha" in text.lower() or "checking your browser" in text.lower():
+                continue
+            if len(text) > max_chars:
+                text = text[:max_chars] + "\n...(truncated)"
+            previews.append(f"### {hit.title}\nURL: {hit.url}\n\n{text}")
+        except Exception as exc:
+            logger.debug("auto-fetch failed for %s: %s", hit.url, exc)
+    return "\n\n---\n\n".join(previews)
+
+
+def _fetch_search_page(search_url: str) -> requests.Response:
+    return requests.get(
+        search_url,
+        headers={"User-Agent": USER_AGENT},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+        allow_redirects=True,
+    )
+
+
+def _s2_fallback_search(query: str, limit: int = 10) -> list[SearchHit]:
+    """Fallback: search Semantic Scholar when DuckDuckGo is unavailable."""
+    try:
+        import httpx
+
+        resp = httpx.get(
+            "https://api.semanticscholar.org/graph/v1/paper/search/bulk",
+            params={
+                "query": query,
+                "limit": limit,
+                "fields": "title,externalIds,year,citationCount,venue,publicationDate",
+            },
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return []
+        papers = resp.json().get("data", [])
+        hits: list[SearchHit] = []
+        for p in papers:
+            title = p.get("title", "")
+            eids = p.get("externalIds") or {}
+            doi = eids.get("DOI")
+            arxiv = eids.get("ArXiv")
+            if doi:
+                url = f"https://doi.org/{doi}"
+            elif arxiv:
+                url = f"https://arxiv.org/abs/{arxiv}"
+            else:
+                s2_id = p.get("paperId", "")
+                url = f"https://www.semanticscholar.org/paper/{s2_id}" if s2_id else ""
+            year = p.get("year", "")
+            venue = p.get("venue", "")
+            suffix = f" ({venue}, {year})" if venue and year else f" ({year})" if year else ""
+            if url:
+                hits.append(SearchHit(title=f"{title}{suffix}", url=url))
+        return hits
+    except Exception as exc:
+        logger.debug("S2 fallback search failed: %s", exc)
+        return []
+
+
+def execute_web_search(
+    query: str,
+    allowed_domains: list[str] | None = None,
+    blocked_domains: list[str] | None = None,
+    tool_use_id: str = "web_search_1",
+) -> dict[str, Any]:
+    started = time.monotonic()
+    search_url = build_search_url(query)
+
+    hits: list[SearchHit] = []
+    for attempt in range(2):
+        response = _fetch_search_page(search_url)
+        hits = extract_search_hits(response.text)
+        if hits:
+            break
+        if attempt == 0:
+            time.sleep(1)
+
+    if not hits and urlparse(response.url or search_url).hostname:
+        hits = extract_search_hits_from_generic_links(response.text)
+
+    # Filter out DDG's own pages (homepage, redirects) that aren't real results.
+    hits = [h for h in hits if not h.url.rstrip("/").endswith("duckduckgo.com/html")]
+
+    # Fallback to Semantic Scholar academic search when DDG returns nothing.
+    used_s2_fallback = False
+    if not hits:
+        logger.info("web_search: DDG returned no results, falling back to Semantic Scholar")
+        hits = _s2_fallback_search(query, limit=MAX_RESULTS)
+        used_s2_fallback = bool(hits)
+
+    if allowed_domains is not None:
+        hits = [hit for hit in hits if host_matches_list(hit.url, allowed_domains)]
+    if blocked_domains is not None:
+        hits = [hit for hit in hits if not host_matches_list(hit.url, blocked_domains)]
+
+    hits = dedupe_hits(hits)[:MAX_RESULTS]
+    logger.info(
+        "web_search: query=%r results=%d%s (%.1fs)",
+        query,
+        len(hits),
+        " [S2 fallback]" if used_s2_fallback else "",
+        time.monotonic() - started,
+    )
+
+    # Auto-fetch top results to give the agent actual content
+    page_previews = _auto_fetch_top_hits(hits, max_fetch=AUTO_FETCH_COUNT)
+
+    rendered_hits = "\n".join(f"- [{hit.title}]({hit.url})" for hit in hits)
+    if hits:
+        source_note = " (via Semantic Scholar academic search)" if used_s2_fallback else ""
+        summary = (
+            f"Search results for {query!r}{source_note}. Include a Sources section in the final answer.\n"
+            f"{rendered_hits}"
+        )
+        if page_previews:
+            summary += "\n\n--- Fetched page previews ---\n" + page_previews
+    else:
+        summary = f"No web search results matched the query {query!r}."
+
+    return {
+        "query": query,
+        "results": [
+            summary,
+            {
+                "tool_use_id": tool_use_id,
+                "content": [hit.as_json() for hit in hits],
+            },
+        ],
+        "durationSeconds": time.monotonic() - started,
+    }
+
+
+WEB_SEARCH_TOOL_SPEC = {
+    "name": "web_search",
+    "description": "Search the web for current information and return cited results.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "minLength": 2},
+            "allowed_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional allowlist of domains or URLs. Subdomains match.",
+            },
+            "blocked_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional blocklist of domains or URLs. Subdomains match.",
+            },
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _optional_string_list(arguments: dict[str, Any], key: str) -> list[str] | None:
+    value = arguments.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{key} must be an array of strings")
+    return value
+
+
+async def web_search_handler(
+    arguments: dict[str, Any],
+    session: Any = None,
+    tool_call_id: str | None = None,
+    **_kw: Any,
+) -> tuple[str, bool]:
+    query_value = arguments.get("query", "")
+    if not isinstance(query_value, str):
+        return "Error: web_search requires a query string with at least 2 characters.", False
+
+    query = query_value.strip()
+    if len(query) < 2:
+        return "Error: web_search requires a query with at least 2 characters.", False
+
+    try:
+        output = await asyncio.to_thread(
+            execute_web_search,
+            query=query,
+            allowed_domains=_optional_string_list(arguments, "allowed_domains"),
+            blocked_domains=_optional_string_list(arguments, "blocked_domains"),
+            tool_use_id=tool_call_id or "web_search_1",
+        )
+    except Exception as exc:
+        return f"Error executing web search: {exc}", False
+
+    return json.dumps(output, indent=2), True


### PR DESCRIPTION
Adding internet and research paper tools for open world search tasks

the tools allow the agent to search papers and understand existing methods before trying introducing alterations to the solution set.

I've used these tools on my own project for determining protein aggregation laws using a skydiscover derivative and found them really useful!

These tools are heavily inspired by huggingface's https://github.com/huggingface/ml-intern