### PR TITLE
Generalize format_diff_summary for C/C++/CUDA languages

### DIFF
--- a/skydiscover/utils/code_utils.py
+++ b/skydiscover/utils/code_utils.py
@@ -242,7 +242,7 @@ def _extract_c_comment(solution: str, func_start: int) -> Optional[str]:
         return "\n".join(comment_lines)
 
     # Fallback: look for comments inside the function body
-    return _extract_first_comment(solution, func_start, is_c_style=True)
+    return _extract_first_comment(solution, func_start)
 
 
 def _extract_docstring(solution: str, start_pos: int) -> Optional[str]:

--- a/skydiscover/utils/code_utils.py
+++ b/skydiscover/utils/code_utils.py
@@ -126,7 +126,9 @@ def _extract_def_info(solution: str) -> Optional[Tuple[str, str, Optional[str]]]
     cuda_kernel_match = re.search(
         r"^\s*(?:__global__|__device__|__host__(?:\s+__device__)?)\s+"
         r"(?:__launch_bounds__\([^)]*\)\s*)?"
-        r"(?:\w+\s+)*?(\w+)\s*\(",
+        r"(?:\w+\s+)*?"
+        r"(?:__launch_bounds__\([^)]*\)\s*)?"
+        r"(\w+)\s*\(",
         solution,
         re.MULTILINE,
     )
@@ -137,9 +139,9 @@ def _extract_def_info(solution: str) -> Optional[Tuple[str, str, Optional[str]]]
         return (kind, name, _truncate_comment(comment))
 
     c_func_match = re.search(
-        r"^\s*(?:static\s+|inline\s+|__inline__\s+)*"
-        r"(?:void|int|float|double|half|bool|char|unsigned|long|size_t|auto|\w+_t)\s+"
-        r"(?:\*\s*)?(\w+)\s*\(",
+        r"^\s*(?:static\s+|inline\s+|__inline__\s+|const\s+)*"
+        r"(?:void|int|float|double|half|bool|char|unsigned|long|size_t|auto|\w+_t)"
+        r"(?:\s*\*+\s*|\s+)(\w+)\s*\(",
         solution,
         re.MULTILINE,
     )

--- a/skydiscover/utils/code_utils.py
+++ b/skydiscover/utils/code_utils.py
@@ -134,7 +134,9 @@ def _extract_def_info(solution: str) -> Optional[Tuple[str, str, Optional[str]]]
     )
     if cuda_kernel_match:
         name = cuda_kernel_match.group(1)
-        kind = "kernel" if "__global__" in solution[: cuda_kernel_match.end()] else "device function"
+        kind = (
+            "kernel" if "__global__" in solution[: cuda_kernel_match.end()] else "device function"
+        )
         comment = _extract_c_comment(solution, cuda_kernel_match.start())
         return (kind, name, _truncate_comment(comment))
 
@@ -184,6 +186,7 @@ def _extract_first_comment(solution: str, func_start: int) -> Optional[str]:
 
     # Collect consecutive comment lines (# for Python, // for C/C++, /* */ for C/C++)
     comment_lines = []
+    in_block_comment = False
     for line in body.split("\n"):
         stripped = line.strip()
         if stripped.startswith("#"):
@@ -195,14 +198,18 @@ def _extract_first_comment(solution: str, func_start: int) -> Optional[str]:
             if comment_text:
                 comment_lines.append(comment_text)
         elif stripped.startswith("/*"):
+            in_block_comment = "*/" not in stripped
             inline_match = re.match(r"/\*\s*(.*?)\s*\*/", stripped)
             if inline_match and inline_match.group(1):
                 comment_lines.append(inline_match.group(1))
-        elif stripped.startswith("*") and not stripped.startswith("*/"):
-            comment_text = stripped.lstrip("* ").strip()
-            if comment_text:
-                comment_lines.append(comment_text)
-        elif stripped and not stripped.startswith(("//", "#", "/*", "*")):
+        elif in_block_comment and stripped.startswith("*"):
+            if stripped.startswith("*/"):
+                in_block_comment = False
+            else:
+                comment_text = stripped.lstrip("* ").strip()
+                if comment_text:
+                    comment_lines.append(comment_text)
+        elif stripped and not stripped.startswith(("//", "#", "/*")):
             break
 
     return "\n".join(comment_lines) if comment_lines else None

--- a/skydiscover/utils/code_utils.py
+++ b/skydiscover/utils/code_utils.py
@@ -240,7 +240,7 @@ def _extract_c_comment(solution: str, func_start: int) -> Optional[str]:
         return "\n".join(comment_lines)
 
     # Fallback: look for comments inside the function body
-    return _extract_first_comment(solution, func_start)
+    return _extract_first_comment(solution, func_start, is_c_style=True)
 
 
 def _extract_docstring(solution: str, start_pos: int) -> Optional[str]:

--- a/skydiscover/utils/code_utils.py
+++ b/skydiscover/utils/code_utils.py
@@ -7,6 +7,8 @@ import re
 from pathlib import Path
 from typing import List, Optional, Set, Tuple
 
+_MAX_COMMENT_LINES = 5
+
 
 def apply_diff(original_solution: str, diff_text: str) -> str:
     """
@@ -84,31 +86,73 @@ def parse_full_rewrite(llm_response: str, language: str = "python") -> Optional[
     return llm_response
 
 
+def _truncate_comment(comment: Optional[str]) -> Optional[str]:
+    """Limit a multi-line comment string to _MAX_COMMENT_LINES lines."""
+    if not comment:
+        return comment
+    lines = comment.split("\n")
+    return "\n".join(lines[:_MAX_COMMENT_LINES])
+
+
 def _extract_def_info(solution: str) -> Optional[Tuple[str, str, Optional[str]]]:
     """
     Extract function/class name and docstring (or first comment as fallback) from solution block.
 
+    Supports Python (def/class), C/C++/CUDA (__global__, __device__, __host__,
+    void/int/float/etc function signatures, struct/class).
+
     Returns:
-        Tuple of (kind, name, docstring_first_line) or None if not found
+        Tuple of (kind, name, comment) or None if not found.
+        The comment is truncated to _MAX_COMMENT_LINES lines.
     """
-    # Look for function definition
+    # --- Python ---
     func_match = re.search(r"^\s*def\s+(\w+)\s*\(", solution, re.MULTILINE)
     if func_match:
         name = func_match.group(1)
-        # Try to extract docstring, fallback to first comment
-        docstring = _extract_docstring(solution, func_match.end())
-        if not docstring:
-            docstring = _extract_first_comment(solution, func_match.start())
-        return ("function", name, docstring)
+        comment = _extract_docstring(solution, func_match.end())
+        if not comment:
+            comment = _extract_first_comment(solution, func_match.start())
+        return ("function", name, _truncate_comment(comment))
 
-    # Look for class definition
     class_match = re.search(r"^\s*class\s+(\w+)", solution, re.MULTILINE)
     if class_match:
         name = class_match.group(1)
-        docstring = _extract_docstring(solution, class_match.end())
-        if not docstring:
-            docstring = _extract_first_comment(solution, class_match.start())
-        return ("class", name, docstring)
+        comment = _extract_docstring(solution, class_match.end())
+        if not comment:
+            comment = _extract_first_comment(solution, class_match.start())
+        return ("class", name, _truncate_comment(comment))
+
+    # --- C/C++/CUDA ---
+    cuda_kernel_match = re.search(
+        r"^\s*(?:__global__|__device__|__host__(?:\s+__device__)?)\s+"
+        r"(?:__launch_bounds__\([^)]*\)\s*)?"
+        r"(?:\w+\s+)*?(\w+)\s*\(",
+        solution,
+        re.MULTILINE,
+    )
+    if cuda_kernel_match:
+        name = cuda_kernel_match.group(1)
+        kind = "kernel" if "__global__" in solution[: cuda_kernel_match.end()] else "device function"
+        comment = _extract_c_comment(solution, cuda_kernel_match.start())
+        return (kind, name, _truncate_comment(comment))
+
+    c_func_match = re.search(
+        r"^\s*(?:static\s+|inline\s+|__inline__\s+)*"
+        r"(?:void|int|float|double|half|bool|char|unsigned|long|size_t|auto|\w+_t)\s+"
+        r"(?:\*\s*)?(\w+)\s*\(",
+        solution,
+        re.MULTILINE,
+    )
+    if c_func_match:
+        name = c_func_match.group(1)
+        comment = _extract_c_comment(solution, c_func_match.start())
+        return ("function", name, _truncate_comment(comment))
+
+    cpp_class_match = re.search(r"^\s*(?:struct|class)\s+(\w+)", solution, re.MULTILINE)
+    if cpp_class_match:
+        name = cpp_class_match.group(1)
+        comment = _extract_c_comment(solution, cpp_class_match.start())
+        return ("struct", name, _truncate_comment(comment))
 
     return None
 
@@ -117,34 +161,86 @@ def _extract_first_comment(solution: str, func_start: int) -> Optional[str]:
     """
     Extract consecutive comment lines inside a function/class body.
     Used as fallback when no docstring is available.
-    Returns up to 5 lines of comments joined together.
+    Supports Python (#) and C/C++ (//, /* */) comment styles.
+    Returns all consecutive comment lines joined together (truncation
+    is applied by the caller via _MAX_COMMENT_LINES).
     """
     remaining = solution[func_start:]
+    # Python: look for colon-newline to find body start
     colon_match = re.search(r"(?:\)|[^:]+):\s*\n", remaining)
-    if not colon_match:
-        return None
+    if colon_match:
+        body_start = colon_match.end()
+    else:
+        # C/C++: look for opening brace to find body start
+        brace_match = re.search(r"\{\s*\n", remaining)
+        if brace_match:
+            body_start = brace_match.end()
+        else:
+            return None
 
-    # Get the body after the colon
-    body_start = colon_match.end()
     body = remaining[body_start:]
 
-    # Collect consecutive comment lines
+    # Collect consecutive comment lines (# for Python, // for C/C++, /* */ for C/C++)
     comment_lines = []
-    lines = body.split("\n")
-    for line in lines[:10]:  # Check first 10 lines for comments
+    for line in body.split("\n"):
         stripped = line.strip()
         if stripped.startswith("#"):
-            # Remove the # and leading space
             comment_text = stripped[1:].strip()
             if comment_text:
                 comment_lines.append(comment_text)
-            if len(comment_lines) >= 5:  # Max 5 lines
-                break
-        elif stripped and not stripped.startswith("#"):
-            # Hit actual code, stop collecting
+        elif stripped.startswith("//"):
+            comment_text = stripped[2:].strip()
+            if comment_text:
+                comment_lines.append(comment_text)
+        elif stripped.startswith("/*"):
+            inline_match = re.match(r"/\*\s*(.*?)\s*\*/", stripped)
+            if inline_match and inline_match.group(1):
+                comment_lines.append(inline_match.group(1))
+        elif stripped.startswith("*") and not stripped.startswith("*/"):
+            comment_text = stripped.lstrip("* ").strip()
+            if comment_text:
+                comment_lines.append(comment_text)
+        elif stripped and not stripped.startswith(("//", "#", "/*", "*")):
             break
 
     return "\n".join(comment_lines) if comment_lines else None
+
+
+def _extract_c_comment(solution: str, func_start: int) -> Optional[str]:
+    """
+    Extract the comment block (/* ... */ or // lines) immediately preceding
+    a C/C++/CUDA function definition. Returns all meaningful lines
+    (truncation is applied by the caller via _MAX_COMMENT_LINES).
+    """
+    preceding = solution[:func_start].rstrip()
+
+    # Check for block comment ending just before the function
+    block_match = re.search(r"/\*\*(.*?)\*/\s*$", preceding, re.DOTALL)
+    if not block_match:
+        block_match = re.search(r"/\*(.*?)\*/\s*$", preceding, re.DOTALL)
+    if block_match:
+        content = block_match.group(1).strip()
+        lines = [l.strip().lstrip("* ").strip() for l in content.split("\n")]
+        meaningful = [l for l in lines if l]
+        return "\n".join(meaningful) if meaningful else None
+
+    # Check for consecutive // comment lines immediately before
+    preceding_lines = preceding.split("\n")
+    comment_lines = []
+    for line in reversed(preceding_lines):
+        stripped = line.strip()
+        if stripped.startswith("//"):
+            comment_lines.append(stripped[2:].strip())
+        elif stripped == "":
+            continue
+        else:
+            break
+    if comment_lines:
+        comment_lines.reverse()
+        return "\n".join(comment_lines)
+
+    # Fallback: look for comments inside the function body
+    return _extract_first_comment(solution, func_start)
 
 
 def _extract_docstring(solution: str, start_pos: int) -> Optional[str]:

--- a/tests/utils/test_code_utils.py
+++ b/tests/utils/test_code_utils.py
@@ -77,7 +77,7 @@ class TestExtractDefInfoCUDA:
         assert name == "my_kernel"
         assert docstring == "Process one element per thread"
 
-    def test_global_kernel_with_launch_bounds(self):
+    def test_launch_bounds_before_return_type(self):
         code = """__global__ __launch_bounds__(256, 4)
 void fused_layer_norm(const half* x, half* y, int hidden, float eps) {
     // One block per row; blockDim=256
@@ -89,6 +89,18 @@ void fused_layer_norm(const half* x, half* y, int hidden, float eps) {
         assert kind == "kernel"
         assert name == "fused_layer_norm"
         assert "One block per row" in docstring
+
+    def test_launch_bounds_after_return_type(self):
+        code = """__global__ void __launch_bounds__(256, 4) fused_layer_norm(const half* x, half* y) {
+    // Alternate placement of launch_bounds
+    const int row = blockIdx.x;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "kernel"
+        assert name == "fused_layer_norm"
+        assert "Alternate placement" in docstring
 
     def test_device_function(self):
         code = """__device__ float warp_reduce_sum(float val) {
@@ -160,6 +172,18 @@ class TestExtractDefInfoCCpp:
         assert kind == "function"
         assert name == "fast_rsqrt"
         assert docstring == "Quake III fast inverse square root"
+
+    def test_const_pointer_function(self):
+        code = """const char** get_names() {
+    // Return list of names
+    return names;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "function"
+        assert name == "get_names"
+        assert docstring == "Return list of names"
 
     def test_struct(self):
         code = """struct SharedMemLayout {

--- a/tests/utils/test_code_utils.py
+++ b/tests/utils/test_code_utils.py
@@ -142,7 +142,6 @@ __global__ void norm_kernel(float* x, int n) {
         assert "Handles hidden=128 case specifically" in docstring
 
 
-
 # ---------------------------------------------------------------------------
 # _extract_def_info — C/C++
 # ---------------------------------------------------------------------------
@@ -198,7 +197,6 @@ class TestExtractDefInfoCCpp:
         assert name == "SharedMemLayout"
 
 
-
 # ---------------------------------------------------------------------------
 # _extract_def_info — no match
 # ---------------------------------------------------------------------------
@@ -246,7 +244,6 @@ class TestExtractFirstCommentCStyle:
         result = _extract_first_comment(code, 0)
         assert result is not None
         assert "Step 1: load data" in result
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_code_utils.py
+++ b/tests/utils/test_code_utils.py
@@ -1,0 +1,426 @@
+"""Tests for skydiscover.utils.code_utils — diff parsing, summary generation, and language support."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load code_utils directly from file to avoid pulling in the full skydiscover
+# package (which requires openai, yaml, etc. not needed for these unit tests).
+_code_utils_path = Path(__file__).resolve().parents[2] / "skydiscover" / "utils" / "code_utils.py"
+_spec = importlib.util.spec_from_file_location("code_utils", _code_utils_path)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+_extract_c_comment = _mod._extract_c_comment
+_extract_def_info = _mod._extract_def_info
+_extract_first_comment = _mod._extract_first_comment
+apply_diff = _mod.apply_diff
+extract_diffs = _mod.extract_diffs
+format_diff_summary = _mod.format_diff_summary
+
+
+# ---------------------------------------------------------------------------
+# _extract_def_info — Python
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDefInfoPython:
+    def test_function_with_docstring(self):
+        code = '''def solve(x, y):
+    """Compute the sum of x and y."""
+    return x + y
+'''
+        result = _extract_def_info(code)
+        assert result == ("function", "solve", "Compute the sum of x and y.")
+
+    def test_function_with_comment(self):
+        code = """def optimize(params):
+    # Gradient descent optimizer
+    lr = 0.01
+    return params - lr * grad
+"""
+        result = _extract_def_info(code)
+        assert result == ("function", "optimize", "Gradient descent optimizer")
+
+    def test_class_with_docstring(self):
+        code = '''class MyModel:
+    """A neural network model."""
+    pass
+'''
+        result = _extract_def_info(code)
+        assert result == ("class", "MyModel", "A neural network model.")
+
+    def test_function_no_docstring_no_comment(self):
+        code = """def bare_func(x):
+    return x * 2
+"""
+        result = _extract_def_info(code)
+        assert result == ("function", "bare_func", None)
+
+
+# ---------------------------------------------------------------------------
+# _extract_def_info — CUDA
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDefInfoCUDA:
+    def test_global_kernel(self):
+        code = """__global__ void my_kernel(float* data, int n) {
+    // Process one element per thread
+    int tid = threadIdx.x;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "kernel"
+        assert name == "my_kernel"
+        assert docstring == "Process one element per thread"
+
+    def test_global_kernel_with_launch_bounds(self):
+        code = """__global__ __launch_bounds__(256, 4)
+void fused_layer_norm(const half* x, half* y, int hidden, float eps) {
+    // One block per row; blockDim=256
+    const int row = blockIdx.x;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "kernel"
+        assert name == "fused_layer_norm"
+        assert "One block per row" in docstring
+
+    def test_device_function(self):
+        code = """__device__ float warp_reduce_sum(float val) {
+    // Butterfly warp reduction
+    val += __shfl_down_sync(0xffffffff, val, 16);
+    return val;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "device function"
+        assert name == "warp_reduce_sum"
+        assert docstring == "Butterfly warp reduction"
+
+    def test_kernel_with_preceding_block_comment(self):
+        code = """/* Fast parallel reduction for SM90 */
+__global__ void reduce_kernel(float* data, int n) {
+    int tid = threadIdx.x;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "kernel"
+        assert name == "reduce_kernel"
+        assert docstring == "Fast parallel reduction for SM90"
+
+    def test_kernel_with_preceding_line_comments(self):
+        code = """// H100-optimized warp shuffle reduction
+// Handles hidden=128 case specifically
+__global__ void norm_kernel(float* x, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "kernel"
+        assert name == "norm_kernel"
+        assert "H100-optimized warp shuffle reduction" in docstring
+        assert "Handles hidden=128 case specifically" in docstring
+
+
+
+# ---------------------------------------------------------------------------
+# _extract_def_info — C/C++
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDefInfoCCpp:
+    def test_void_function(self):
+        code = """void process_data(int* buf, size_t len) {
+    /* Zero-initialize the buffer */
+    memset(buf, 0, len * sizeof(int));
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "function"
+        assert name == "process_data"
+        assert docstring == "Zero-initialize the buffer"
+
+    def test_static_inline_function(self):
+        code = """static inline float fast_rsqrt(float x) {
+    // Quake III fast inverse square root
+    return 1.0f / sqrtf(x);
+}"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, docstring = result
+        assert kind == "function"
+        assert name == "fast_rsqrt"
+        assert docstring == "Quake III fast inverse square root"
+
+    def test_struct(self):
+        code = """struct SharedMemLayout {
+    float warp_sums[8];
+    float mean;
+    float inv_std;
+};"""
+        result = _extract_def_info(code)
+        assert result is not None
+        kind, name, _ = result
+        assert kind == "struct"
+        assert name == "SharedMemLayout"
+
+
+
+# ---------------------------------------------------------------------------
+# _extract_def_info — no match
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDefInfoNoMatch:
+    def test_no_recognizable_pattern(self):
+        assert _extract_def_info("hello world") is None
+        assert _extract_def_info("") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_first_comment — C-style
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFirstCommentCStyle:
+    def test_double_slash_comments(self):
+        code = """void func() {
+    // First comment line
+    // Second comment line
+    int x = 0;
+}"""
+        result = _extract_first_comment(code, 0)
+        assert result is not None
+        assert "First comment line" in result
+        assert "Second comment line" in result
+
+    def test_block_comment_inline(self):
+        code = """void func() {
+    /* Initialize the accumulator */
+    float acc = 0.0f;
+}"""
+        result = _extract_first_comment(code, 0)
+        assert result == "Initialize the accumulator"
+
+    def test_multiline_block_comment_continuation(self):
+        code = """void func() {
+    /*
+     * Step 1: load data
+     * Step 2: compute
+     */
+    int x = 0;
+}"""
+        result = _extract_first_comment(code, 0)
+        assert result is not None
+        assert "Step 1: load data" in result
+
+
+
+# ---------------------------------------------------------------------------
+# _extract_c_comment
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCComment:
+    def test_block_comment_before_function(self):
+        code = """/* Compute mean and variance in one pass */
+void compute_stats(float* data, int n) {
+    float sum = 0;
+}"""
+        func_start = code.index("void")
+        result = _extract_c_comment(code, func_start)
+        assert result == "Compute mean and variance in one pass"
+
+    def test_line_comments_before_function(self):
+        code = """// Fast reciprocal square root
+// Optimized for H100 SM90
+__global__ void kernel(float* x) {
+    int tid = threadIdx.x;
+}"""
+        func_start = code.index("__global__")
+        result = _extract_c_comment(code, func_start)
+        assert "Fast reciprocal square root" in result
+        assert "Optimized for H100 SM90" in result
+
+    def test_no_comment_falls_back_to_body(self):
+        code = """__global__ void kernel(float* x) {
+    // Body comment here
+    int tid = threadIdx.x;
+}"""
+        func_start = code.index("__global__")
+        result = _extract_c_comment(code, func_start)
+        assert result == "Body comment here"
+
+    def test_no_comment_anywhere(self):
+        code = """__global__ void kernel(float* x) {
+    int tid = threadIdx.x;
+}"""
+        func_start = code.index("__global__")
+        result = _extract_c_comment(code, func_start)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# format_diff_summary — CUDA integration
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDiffSummaryCUDA:
+    def test_modified_kernel_same_comment(self):
+        old = """__global__ void my_kernel(float* x, int n) {
+    // Process elements
+    int tid = threadIdx.x;
+    x[tid] = x[tid] * 2.0f;
+}"""
+        new = """__global__ void my_kernel(float* x, int n) {
+    // Process elements
+    int tid = threadIdx.x;
+    x[tid] = x[tid] * 3.0f;
+    __syncthreads();
+}"""
+        summary = format_diff_summary([(old, new)])
+        assert "my_kernel" in summary
+        assert "kernel" in summary.lower()
+        # Same docstring -> line count format
+        assert "→" in summary or "->" in summary or "lines" in summary
+
+    def test_modified_kernel_different_comment(self):
+        old = """__global__ void my_kernel(float* x, int n) {
+    // Old approach: scalar loads
+    int tid = threadIdx.x;
+}"""
+        new = """__global__ void my_kernel(float* x, int n) {
+    // New approach: vectorized loads
+    int tid = threadIdx.x;
+}"""
+        summary = format_diff_summary([(old, new)])
+        assert "my_kernel" in summary
+        assert "New approach: vectorized loads" in summary
+
+    def test_renamed_kernel(self):
+        old = """__global__ void old_kernel(float* x) {
+    int tid = threadIdx.x;
+}"""
+        new = """__global__ void new_kernel(float* x) {
+    int tid = threadIdx.x;
+}"""
+        summary = format_diff_summary([(old, new)])
+        assert "old_kernel" in summary
+        assert "new_kernel" in summary
+        assert "Renamed" in summary
+
+
+# ---------------------------------------------------------------------------
+# format_diff_summary — Python (preserve existing behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDiffSummaryPython:
+    def test_modified_function_same_docstring(self):
+        old = '''def solve(x):
+    """Compute solution."""
+    return x + 1
+'''
+        new = '''def solve(x):
+    """Compute solution."""
+    return x + 2
+'''
+        summary = format_diff_summary([(old, new)])
+        assert "solve" in summary
+        assert "function" in summary.lower()
+
+    def test_renamed_function(self):
+        old = '''def old_name(x):
+    """Do something."""
+    return x
+'''
+        new = '''def new_name(x):
+    """Do something."""
+    return x
+'''
+        summary = format_diff_summary([(old, new)])
+        assert "old_name" in summary
+        assert "new_name" in summary
+        assert "Renamed" in summary
+
+    def test_fallback_no_function(self):
+        old = "x = 1\ny = 2\nz = 3"
+        new = "x = 10\ny = 20\nz = 30"
+        summary = format_diff_summary([(old, new)])
+        assert "Change 1" in summary
+
+
+# ---------------------------------------------------------------------------
+# extract_diffs and apply_diff (existing functionality)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDiffs:
+    def test_single_block(self):
+        text = """Some explanation.
+
+<<<<<<< SEARCH
+old line 1
+old line 2
+=======
+new line 1
+new line 2
+new line 3
+>>>>>>> REPLACE
+
+Done."""
+        blocks = extract_diffs(text)
+        assert len(blocks) == 1
+        assert blocks[0][0] == "old line 1\nold line 2"
+        assert blocks[0][1] == "new line 1\nnew line 2\nnew line 3"
+
+    def test_multiple_blocks(self):
+        text = """<<<<<<< SEARCH
+a
+=======
+b
+>>>>>>> REPLACE
+
+<<<<<<< SEARCH
+c
+=======
+d
+>>>>>>> REPLACE"""
+        blocks = extract_diffs(text)
+        assert len(blocks) == 2
+        assert blocks[0] == ("a", "b")
+        assert blocks[1] == ("c", "d")
+
+    def test_no_blocks(self):
+        assert extract_diffs("no diffs here") == []
+
+
+class TestApplyDiff:
+    def test_simple_replacement(self):
+        original = "line 1\nline 2\nline 3"
+        diff = """<<<<<<< SEARCH
+line 2
+=======
+replaced line 2
+>>>>>>> REPLACE"""
+        result = apply_diff(original, diff)
+        assert result == "line 1\nreplaced line 2\nline 3"
+
+    def test_no_match_returns_original(self):
+        original = "line 1\nline 2"
+        diff = """<<<<<<< SEARCH
+nonexistent
+=======
+replacement
+>>>>>>> REPLACE"""
+        result = apply_diff(original, diff)
+        assert result == original

--- a/tests/utils/test_code_utils.py
+++ b/tests/utils/test_code_utils.py
@@ -58,6 +58,14 @@ class TestExtractDefInfoPython:
         result = _extract_def_info(code)
         assert result == ("function", "bare_func", None)
 
+    def test_star_unpack_not_treated_as_comment(self):
+        code = """def k():
+    *rest, last = [1, 2, 3]
+    return last
+"""
+        result = _extract_def_info(code)
+        assert result == ("function", "k", None)
+
 
 # ---------------------------------------------------------------------------
 # _extract_def_info — CUDA


### PR DESCRIPTION
## Summary

`format_diff_summary` (used to populate `metadata.changes` on programs) only recognized
Python `def`/`class` patterns. For non-Python code (e.g. CUDA kernels), it fell through
to a generic fallback that truncated the first line at 50 characters resulting in descriptions of the form "Change 1: Near #include <cuda.h>... (118→76 lines)"


This commit extends _extract_def_info to also recognize:
- CUDA: __global__, __device__, __host__ function signatures (including __launch_bounds__ qualifiers)
- C/C++: void/int/float/etc function signatures (with static/inline qualifiers)
- C++: struct/class definitions

Adds _extract_c_comment() for extracting comments from C-family code (block comments, line comments before or inside function bodies).

Generalizes _extract_first_comment() to handle // and /* */ in addition to Python # comments, and to find function bodies delimited by { in addition to Python's :.

Lastly, added a single constant (`_MAX_COMMENT_LINES = 5`) controlling comment truncation and a method 
(`_truncate_comment()) applying the limit at one place

After this change, CUDA diffs produce summaries like:

  "Change 1: Modified kernel fused_layer_norm_sm80: One block per row; blockDim=256, hidden=128.
Warps 0-3 active (tid 0-127), warps 4-7 idle (tid 128-255).
smem[0..3]=warp sums, [4..7]=warp sq, [8]=mean, [9]=inv_std"

Includes comprehensive test suite (31 tests) covering Python, CUDA, C/C++ patterns, and existing diff parsing functionality.

## Backward compatibility
- Python behavior is unchanged (same code paths, same output)
- The fallback path for unrecognized languages still works as before