### PR TITLE
Add SubprocessEvaluator for process-isolated evaluation

### DIFF
--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -332,6 +332,12 @@ class EvaluatorConfig:
     # This will read from prompt.evaluator_system_message if provided, otherwise use the default system prompt.
     llm_as_judge: bool = False
 
+    # When True, each evaluation runs in a separate Python subprocess.
+    # This provides process-level isolation: if a candidate crashes (e.g. CUDA
+    # illegal memory access, segfault), it cannot corrupt the parent process.
+    # Adds ~100-200ms overhead per evaluation for process startup.
+    subprocess_isolation: bool = False
+
 
 # ═════════════════════════════════════════════════════════════════════════════════════════════
 # 4. Solution Selector — maintains database and strategy to pick prior programs (search/)

--- a/skydiscover/evaluation/__init__.py
+++ b/skydiscover/evaluation/__init__.py
@@ -3,11 +3,14 @@
 Evaluator hierarchy (pick one per benchmark)::
 
     Evaluator                  Python function: evaluate(program_path) -> dict
+    SubprocessEvaluator        Same as Evaluator but each call runs in a child process
     ContainerizedEvaluator     Docker: Dockerfile + evaluate.sh  ->  JSON on stdout
     └── HarborEvaluator        Harbor protocol: instruction.md + tests/test.sh + environment/
 
 ``create_evaluator()`` auto-detects which one to use based on the benchmark
 directory contents.  Detection order: Harbor > Containerized > Python.
+Set ``evaluator.subprocess_isolation: true`` in config to use SubprocessEvaluator
+instead of the in-process Evaluator.
 
 Supporting modules:
 
@@ -25,10 +28,12 @@ from skydiscover.evaluation.evaluation_result import EvaluationResult
 from skydiscover.evaluation.evaluator import Evaluator
 from skydiscover.evaluation.harbor_evaluator import HarborEvaluator
 from skydiscover.evaluation.llm_judge import LLMJudge
+from skydiscover.evaluation.subprocess_evaluator import SubprocessEvaluator
 
 __all__ = [
     "EvaluationResult",
     "Evaluator",
+    "SubprocessEvaluator",
     "ContainerizedEvaluator",
     "HarborEvaluator",
     "LLMJudge",
@@ -61,13 +66,14 @@ def create_evaluator(
     llm_judge: Optional[LLMJudge] = None,
     max_concurrent: int = 4,
     env_vars: Optional[Dict[str, str]] = None,
-) -> Union[Evaluator, ContainerizedEvaluator, HarborEvaluator]:
+) -> Union[Evaluator, SubprocessEvaluator, ContainerizedEvaluator, HarborEvaluator]:
     """Return the right evaluator for the given config.
 
     Detection order (most specific first):
       1. Harbor task — instruction.md + tests/ + environment/Dockerfile
       2. Containerized — Dockerfile + evaluate.sh
-      3. Python evaluator — fallback
+      3. subprocess_isolation=True — SubprocessEvaluator (process-per-evaluation)
+      4. Python evaluator — fallback (in-process)
     """
     path = config.evaluation_file or ""
     if _is_harbor_task(path):
@@ -75,5 +81,9 @@ def create_evaluator(
     if _is_containerized(path):
         return ContainerizedEvaluator(
             path, config, max_concurrent=max_concurrent, env_vars=env_vars
+        )
+    if getattr(config, "subprocess_isolation", False):
+        return SubprocessEvaluator(
+            config, llm_judge=llm_judge, max_concurrent=max_concurrent, env_vars=env_vars
         )
     return Evaluator(config, llm_judge=llm_judge, max_concurrent=max_concurrent, env_vars=env_vars)

--- a/skydiscover/evaluation/subprocess_evaluator.py
+++ b/skydiscover/evaluation/subprocess_evaluator.py
@@ -14,7 +14,6 @@ import errno
 import json
 import logging
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -39,7 +38,9 @@ sys.modules["_eval_mod"] = mod
 spec.loader.exec_module(mod)
 
 result = mod.evaluate(sys.argv[1])
-print(json.dumps(result))
+if hasattr(result, "to_dict"):
+    result = result.to_dict()
+print(json.dumps(result, default=str))
 """
 
 
@@ -77,10 +78,6 @@ class SubprocessEvaluator:
         self.task_pool = TaskPool(max_concurrency=max_concurrent)
         self.env_vars = dict(env_vars or {})
 
-        eval_dir = os.path.dirname(self.evaluation_file)
-        if eval_dir not in sys.path:
-            sys.path.insert(0, eval_dir)
-
         self._wrapper_script = _WRAPPER_TEMPLATE.format(evaluator_path=self.evaluation_file)
         logger.info(
             f"Initialized SubprocessEvaluator with {self.evaluation_file} "
@@ -99,12 +96,13 @@ class SubprocessEvaluator:
 
         last_exception = None
         for attempt in range(self.config.max_retries + 1):
+            temp_path = None
             try:
                 with tempfile.NamedTemporaryFile(
                     suffix=self.program_suffix, delete=False, mode="w", encoding="utf-8"
                 ) as f:
-                    f.write(program_solution)
                     temp_path = f.name
+                    f.write(program_solution)
             except OSError as e:
                 if e.errno == errno.ENOSPC:
                     logger.error("Disk full — cannot create temp file")
@@ -145,7 +143,7 @@ class SubprocessEvaluator:
                     await asyncio.sleep(1.0)
 
             finally:
-                if os.path.exists(temp_path):
+                if temp_path and os.path.exists(temp_path):
                     os.unlink(temp_path)
 
         logger.error(f"All attempts failed{label}: {last_exception}")
@@ -176,39 +174,32 @@ class SubprocessEvaluator:
         else:
             env["PYTHONPATH"] = eval_dir
 
-        loop = asyncio.get_running_loop()
-        proc_result = await asyncio.wait_for(
-            loop.run_in_executor(
-                None,
-                self._execute_subprocess,
-                program_path,
-                env,
-            ),
-            timeout=self.config.timeout,
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-c", self._wrapper_script, program_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            cwd=os.path.dirname(self.evaluation_file),
         )
-        return proc_result
 
-    def _execute_subprocess(self, program_path: str, env: Dict[str, str]) -> Dict[str, Any]:
-        """Run the subprocess synchronously (called from executor thread)."""
         try:
-            result = subprocess.run(
-                [sys.executable, "-c", self._wrapper_script, program_path],
-                capture_output=True,
-                text=True,
-                timeout=self.config.timeout,
-                env=env,
-                cwd=os.path.dirname(self.evaluation_file),
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=self.config.timeout
             )
-        except subprocess.TimeoutExpired:
-            raise asyncio.TimeoutError()
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
 
-        if result.returncode != 0:
-            stderr_tail = result.stderr[-1000:] if result.stderr else ""
+        stdout = stdout_bytes.decode("utf-8", errors="replace").strip()
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            stderr_tail = stderr[-1000:] if stderr else ""
             raise RuntimeError(
-                f"Evaluation subprocess failed (exit {result.returncode}): {stderr_tail}"
+                f"Evaluation subprocess failed (exit {proc.returncode}): {stderr_tail}"
             )
 
-        stdout = result.stdout.strip()
         # Libraries may print warnings to stdout before the JSON.
         # Find the last JSON object in the output.
         json_start = stdout.rfind("\n{")

--- a/skydiscover/evaluation/subprocess_evaluator.py
+++ b/skydiscover/evaluation/subprocess_evaluator.py
@@ -1,0 +1,228 @@
+"""
+Subprocess-isolated evaluator.
+
+Runs each candidate evaluation in a separate Python process so that crashes
+(e.g. CUDA illegal memory access, segfaults, memory corruption) in one
+candidate cannot affect subsequent evaluations.
+
+Sits between the in-process Evaluator (fast, no isolation) and the
+ContainerizedEvaluator (full Docker, high overhead).
+"""
+
+import asyncio
+import errno
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from skydiscover.config import EvaluatorConfig
+from skydiscover.evaluation.evaluation_result import EvaluationResult
+from skydiscover.evaluation.llm_judge import LLMJudge
+from skydiscover.utils.async_utils import TaskPool
+from skydiscover.utils.metrics import format_metrics
+
+logger = logging.getLogger(__name__)
+
+_WRAPPER_TEMPLATE = """\
+import json
+import sys
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("_eval_mod", {evaluator_path!r})
+mod = importlib.util.module_from_spec(spec)
+sys.modules["_eval_mod"] = mod
+spec.loader.exec_module(mod)
+
+result = mod.evaluate(sys.argv[1])
+print(json.dumps(result))
+"""
+
+
+class SubprocessEvaluator:
+    """
+    Runs the user-provided evaluate() function in a child process.
+
+    Each call to evaluate_program() spawns a new Python subprocess that:
+      1. Imports the evaluation module fresh
+      2. Calls evaluate(program_path)
+      3. Prints the result dict as JSON to stdout
+      4. Exits
+
+    This gives full process isolation: if the candidate program corrupts
+    GPU state, segfaults, or leaks memory, only the child dies.
+    """
+
+    def __init__(
+        self,
+        config: EvaluatorConfig,
+        llm_judge: Optional[LLMJudge] = None,
+        max_concurrent: int = 4,
+        env_vars: Optional[Dict[str, str]] = None,
+    ):
+        if not config.evaluation_file:
+            raise ValueError("EvaluatorConfig.evaluation_file must be set")
+        if not os.path.exists(config.evaluation_file):
+            raise ValueError(f"Evaluation file not found: {config.evaluation_file}")
+
+        self.config = config
+        self.evaluation_file = os.path.abspath(config.evaluation_file)
+        self.program_suffix = config.file_suffix
+        self.is_image_mode = config.is_image_mode
+        self.llm_judge = llm_judge
+        self.task_pool = TaskPool(max_concurrency=max_concurrent)
+        self.env_vars = dict(env_vars or {})
+
+        eval_dir = os.path.dirname(self.evaluation_file)
+        if eval_dir not in sys.path:
+            sys.path.insert(0, eval_dir)
+
+        self._wrapper_script = _WRAPPER_TEMPLATE.format(evaluator_path=self.evaluation_file)
+        logger.info(
+            f"Initialized SubprocessEvaluator with {self.evaluation_file} "
+            f"(timeout={config.timeout}s, max_concurrent={max_concurrent})"
+        )
+
+    async def evaluate_program(
+        self,
+        program_solution: str,
+        program_id: str = "",
+        mode: str = "train",
+    ) -> EvaluationResult:
+        """Evaluate a candidate program in an isolated subprocess."""
+        start_time = time.time()
+        label = f" {program_id}" if program_id else ""
+
+        last_exception = None
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                with tempfile.NamedTemporaryFile(
+                    suffix=self.program_suffix, delete=False, mode="w", encoding="utf-8"
+                ) as f:
+                    f.write(program_solution)
+                    temp_path = f.name
+            except OSError as e:
+                if e.errno == errno.ENOSPC:
+                    logger.error("Disk full — cannot create temp file")
+                    return EvaluationResult(metrics={"error": 0.0, "disk_space_error": True})
+                raise
+
+            try:
+                result = await self._run_subprocess(temp_path)
+                eval_result = self._normalize_result(result)
+
+                if self.llm_judge:
+                    llm_result = await self.llm_judge.evaluate(program_solution, program_id)
+                    if llm_result:
+                        for name, value in llm_result.metrics.items():
+                            eval_result.metrics[f"llm_{name}"] = value
+                        eval_result.artifacts.update(llm_result.artifacts)
+
+                elapsed = time.time() - start_time
+                logger.info(
+                    f"Evaluated program{label} in {elapsed:.2f}s: "
+                    f"{format_metrics(eval_result.metrics)}"
+                )
+                return eval_result
+
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"Program{label} timed out after {time.time() - start_time:.0f}s "
+                    f"(limit: {self.config.timeout}s)"
+                )
+                return EvaluationResult(metrics={"error": 0.0, "timeout": True})
+
+            except Exception as e:
+                last_exception = e
+                logger.warning(
+                    f"Attempt {attempt + 1}/{self.config.max_retries + 1} failed{label}: {e}"
+                )
+                if attempt < self.config.max_retries:
+                    await asyncio.sleep(1.0)
+
+            finally:
+                if os.path.exists(temp_path):
+                    os.unlink(temp_path)
+
+        logger.error(f"All attempts failed{label}: {last_exception}")
+        return EvaluationResult(metrics={"error": 0.0})
+
+    async def evaluate_batch(
+        self,
+        programs: List[Tuple[str, str]],
+    ) -> List[EvaluationResult]:
+        """Evaluate multiple programs concurrently (each in its own subprocess)."""
+        return await self.task_pool.gather(
+            coros=[self.evaluate_program] * len(programs),
+            args_list=list(programs),
+        )
+
+    def close(self) -> None:
+        """No persistent resources to clean up."""
+        pass
+
+    async def _run_subprocess(self, program_path: str) -> Dict[str, Any]:
+        """Spawn a child process, run the evaluation, parse JSON result."""
+        env = os.environ.copy()
+        env.update(self.env_vars)
+
+        eval_dir = os.path.dirname(self.evaluation_file)
+        if "PYTHONPATH" in env:
+            env["PYTHONPATH"] = eval_dir + os.pathsep + env["PYTHONPATH"]
+        else:
+            env["PYTHONPATH"] = eval_dir
+
+        loop = asyncio.get_running_loop()
+        proc_result = await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                self._execute_subprocess,
+                program_path,
+                env,
+            ),
+            timeout=self.config.timeout,
+        )
+        return proc_result
+
+    def _execute_subprocess(self, program_path: str, env: Dict[str, str]) -> Dict[str, Any]:
+        """Run the subprocess synchronously (called from executor thread)."""
+        try:
+            result = subprocess.run(
+                [sys.executable, "-c", self._wrapper_script, program_path],
+                capture_output=True,
+                text=True,
+                timeout=self.config.timeout,
+                env=env,
+                cwd=os.path.dirname(self.evaluation_file),
+            )
+        except subprocess.TimeoutExpired:
+            raise asyncio.TimeoutError()
+
+        if result.returncode != 0:
+            stderr_tail = result.stderr[-1000:] if result.stderr else ""
+            raise RuntimeError(
+                f"Evaluation subprocess failed (exit {result.returncode}): {stderr_tail}"
+            )
+
+        stdout = result.stdout.strip()
+        # Libraries may print warnings to stdout before the JSON.
+        # Find the last JSON object in the output.
+        json_start = stdout.rfind("\n{")
+        if json_start != -1:
+            stdout = stdout[json_start + 1:]
+        elif not stdout.startswith("{"):
+            raise RuntimeError(f"No JSON in subprocess output: {stdout[-500:]}")
+
+        return json.loads(stdout)
+
+    def _normalize_result(self, result: Any) -> EvaluationResult:
+        if isinstance(result, EvaluationResult):
+            return result
+        if isinstance(result, dict):
+            return EvaluationResult.from_dict(result)
+        logger.warning(f"Unexpected result type: {type(result)}")
+        return EvaluationResult(metrics={"error": 0.0})

--- a/skydiscover/evaluation/subprocess_evaluator.py
+++ b/skydiscover/evaluation/subprocess_evaluator.py
@@ -32,6 +32,22 @@ import json
 import sys
 import importlib.util
 
+try:
+    from skydiscover.search.utils.checkpoint_manager import SafeJSONEncoder
+except ImportError:
+    class SafeJSONEncoder(json.JSONEncoder):
+        def default(self, obj):
+            try:
+                import numpy as np
+                if isinstance(obj, np.ndarray): return obj.tolist()
+                if isinstance(obj, np.integer): return int(obj)
+                if isinstance(obj, np.floating): return float(obj)
+                if isinstance(obj, np.bool_): return bool(obj)
+            except ImportError:
+                pass
+            if isinstance(obj, (set, frozenset)): return sorted(list(obj))
+            return str(obj)
+
 spec = importlib.util.spec_from_file_location("_eval_mod", {evaluator_path!r})
 mod = importlib.util.module_from_spec(spec)
 sys.modules["_eval_mod"] = mod
@@ -40,7 +56,7 @@ spec.loader.exec_module(mod)
 result = mod.evaluate(sys.argv[1])
 if hasattr(result, "to_dict"):
     result = result.to_dict()
-print(json.dumps(result, default=str))
+print(json.dumps(result, cls=SafeJSONEncoder))
 """
 
 

--- a/skydiscover/evaluation/subprocess_evaluator.py
+++ b/skydiscover/evaluation/subprocess_evaluator.py
@@ -191,7 +191,10 @@ class SubprocessEvaluator:
             env["PYTHONPATH"] = eval_dir
 
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, "-c", self._wrapper_script, program_path,
+            sys.executable,
+            "-c",
+            self._wrapper_script,
+            program_path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
@@ -220,7 +223,7 @@ class SubprocessEvaluator:
         # Find the last JSON object in the output.
         json_start = stdout.rfind("\n{")
         if json_start != -1:
-            stdout = stdout[json_start + 1:]
+            stdout = stdout[json_start + 1 :]
         elif not stdout.startswith("{"):
             raise RuntimeError(f"No JSON in subprocess output: {stdout[-500:]}")
 

--- a/tests/evaluation/test_subprocess_evaluator.py
+++ b/tests/evaluation/test_subprocess_evaluator.py
@@ -1,73 +1,13 @@
 """Tests for SubprocessEvaluator — process isolation and result parsing."""
 
 import asyncio
-import importlib.util
 import os
-import sys
 import tempfile
-from dataclasses import dataclass, field
-from pathlib import Path
 
 import pytest
 
-# Load SubprocessEvaluator directly to avoid pulling in the full skydiscover
-# package (which requires openai, etc. not needed for these tests).
-_eval_dir = Path(__file__).resolve().parents[2] / "skydiscover" / "evaluation"
-
-# Load evaluation_result first (dependency of subprocess_evaluator)
-_er_spec = importlib.util.spec_from_file_location(
-    "skydiscover.evaluation.evaluation_result", _eval_dir / "evaluation_result.py"
-)
-_er_mod = importlib.util.module_from_spec(_er_spec)
-sys.modules["skydiscover.evaluation.evaluation_result"] = _er_mod
-_er_spec.loader.exec_module(_er_mod)
-EvaluationResult = _er_mod.EvaluationResult
-
-# Stub modules that subprocess_evaluator imports
-_metrics_path = Path(__file__).resolve().parents[2] / "skydiscover" / "utils" / "metrics.py"
-_metrics_spec = importlib.util.spec_from_file_location("skydiscover.utils.metrics", _metrics_path)
-_metrics_mod = importlib.util.module_from_spec(_metrics_spec)
-sys.modules["skydiscover.utils.metrics"] = _metrics_mod
-_metrics_spec.loader.exec_module(_metrics_mod)
-
-_async_path = Path(__file__).resolve().parents[2] / "skydiscover" / "utils" / "async_utils.py"
-_async_spec = importlib.util.spec_from_file_location("skydiscover.utils.async_utils", _async_path)
-_async_mod = importlib.util.module_from_spec(_async_spec)
-sys.modules["skydiscover.utils.async_utils"] = _async_mod
-_async_spec.loader.exec_module(_async_mod)
-
-# Stub LLMJudge to avoid importing openai
-sys.modules["skydiscover.evaluation.llm_judge"] = type(sys)("skydiscover.evaluation.llm_judge")
-sys.modules["skydiscover.evaluation.llm_judge"].LLMJudge = None
-
-# Stub skydiscover.config with a minimal EvaluatorConfig
-_config_stub = type(sys)("skydiscover.config")
-
-
-@dataclass
-class _EvaluatorConfig:
-    evaluation_file: str = ""
-    file_suffix: str = ".py"
-    is_image_mode: bool = False
-    timeout: int = 360
-    max_retries: int = 3
-    cascade_evaluation: bool = False
-    cascade_thresholds: list = field(default_factory=lambda: [0.3, 0.6])
-    subprocess_isolation: bool = True
-
-
-_config_stub.EvaluatorConfig = _EvaluatorConfig
-sys.modules["skydiscover.config"] = _config_stub
-
-# Now load subprocess_evaluator
-_sp_spec = importlib.util.spec_from_file_location(
-    "skydiscover.evaluation.subprocess_evaluator", _eval_dir / "subprocess_evaluator.py"
-)
-_sp_mod = importlib.util.module_from_spec(_sp_spec)
-sys.modules["skydiscover.evaluation.subprocess_evaluator"] = _sp_mod
-_sp_spec.loader.exec_module(_sp_mod)
-SubprocessEvaluator = _sp_mod.SubprocessEvaluator
-EvaluatorConfig = _EvaluatorConfig
+from skydiscover.config import EvaluatorConfig
+from skydiscover.evaluation.subprocess_evaluator import SubprocessEvaluator
 
 # --- Mock evaluator scripts written to temp files ---
 

--- a/tests/evaluation/test_subprocess_evaluator.py
+++ b/tests/evaluation/test_subprocess_evaluator.py
@@ -1,0 +1,199 @@
+"""Tests for SubprocessEvaluator — process isolation and result parsing."""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+# Load SubprocessEvaluator directly to avoid pulling in the full skydiscover
+# package (which requires openai, etc. not needed for these tests).
+_eval_dir = Path(__file__).resolve().parents[2] / "skydiscover" / "evaluation"
+
+# Load evaluation_result first (dependency of subprocess_evaluator)
+_er_spec = importlib.util.spec_from_file_location(
+    "skydiscover.evaluation.evaluation_result", _eval_dir / "evaluation_result.py"
+)
+_er_mod = importlib.util.module_from_spec(_er_spec)
+sys.modules["skydiscover.evaluation.evaluation_result"] = _er_mod
+_er_spec.loader.exec_module(_er_mod)
+EvaluationResult = _er_mod.EvaluationResult
+
+# Stub modules that subprocess_evaluator imports
+_metrics_path = Path(__file__).resolve().parents[2] / "skydiscover" / "utils" / "metrics.py"
+_metrics_spec = importlib.util.spec_from_file_location("skydiscover.utils.metrics", _metrics_path)
+_metrics_mod = importlib.util.module_from_spec(_metrics_spec)
+sys.modules["skydiscover.utils.metrics"] = _metrics_mod
+_metrics_spec.loader.exec_module(_metrics_mod)
+
+_async_path = Path(__file__).resolve().parents[2] / "skydiscover" / "utils" / "async_utils.py"
+_async_spec = importlib.util.spec_from_file_location("skydiscover.utils.async_utils", _async_path)
+_async_mod = importlib.util.module_from_spec(_async_spec)
+sys.modules["skydiscover.utils.async_utils"] = _async_mod
+_async_spec.loader.exec_module(_async_mod)
+
+# Stub LLMJudge to avoid importing openai
+sys.modules["skydiscover.evaluation.llm_judge"] = type(sys)("skydiscover.evaluation.llm_judge")
+sys.modules["skydiscover.evaluation.llm_judge"].LLMJudge = None
+
+# Stub skydiscover.config with a minimal EvaluatorConfig
+_config_stub = type(sys)("skydiscover.config")
+
+
+@dataclass
+class _EvaluatorConfig:
+    evaluation_file: str = ""
+    file_suffix: str = ".py"
+    is_image_mode: bool = False
+    timeout: int = 360
+    max_retries: int = 3
+    cascade_evaluation: bool = False
+    cascade_thresholds: list = field(default_factory=lambda: [0.3, 0.6])
+    subprocess_isolation: bool = True
+
+
+_config_stub.EvaluatorConfig = _EvaluatorConfig
+sys.modules["skydiscover.config"] = _config_stub
+
+# Now load subprocess_evaluator
+_sp_spec = importlib.util.spec_from_file_location(
+    "skydiscover.evaluation.subprocess_evaluator", _eval_dir / "subprocess_evaluator.py"
+)
+_sp_mod = importlib.util.module_from_spec(_sp_spec)
+sys.modules["skydiscover.evaluation.subprocess_evaluator"] = _sp_mod
+_sp_spec.loader.exec_module(_sp_mod)
+SubprocessEvaluator = _sp_mod.SubprocessEvaluator
+EvaluatorConfig = _EvaluatorConfig
+
+# --- Mock evaluator scripts written to temp files ---
+
+EVALUATOR_SUCCESS = """\
+import json
+
+def evaluate(program_path):
+    with open(program_path) as f:
+        code = f.read()
+    return {"combined_score": 0.85, "lines": len(code.splitlines())}
+"""
+
+EVALUATOR_CRASH = """\
+import os, signal
+
+def evaluate(program_path):
+    # Simulate a crash (e.g. CUDA illegal memory access / segfault)
+    os.kill(os.getpid(), signal.SIGTERM)
+"""
+
+EVALUATOR_RETURNS_ERROR = """\
+def evaluate(program_path):
+    raise RuntimeError("CUDA error: illegal memory access")
+"""
+
+EVALUATOR_NOISY_STDOUT = """\
+import json
+
+print("WARNING: some library noise on stdout")
+print("Another warning line")
+
+def evaluate(program_path):
+    return {"combined_score": 0.5}
+"""
+
+
+def _write_temp_evaluator(source: str) -> str:
+    """Write evaluator source to a temp .py file and return its path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
+    f.write(source)
+    f.close()
+    return f.name
+
+
+def _make_config(eval_file: str, timeout: int = 30) -> EvaluatorConfig:
+    config = EvaluatorConfig()
+    config.evaluation_file = eval_file
+    config.timeout = timeout
+    config.max_retries = 0
+    config.subprocess_isolation = True
+    return config
+
+
+class TestSubprocessEvaluatorSuccess:
+    def test_returns_metrics(self, tmp_path):
+        eval_file = _write_temp_evaluator(EVALUATOR_SUCCESS)
+        try:
+            evaluator = SubprocessEvaluator(_make_config(eval_file))
+            result = asyncio.run(evaluator.evaluate_program("x = 1\ny = 2\n"))
+            assert result.metrics["combined_score"] == 0.85
+            assert result.metrics["lines"] == 2
+        finally:
+            os.unlink(eval_file)
+
+    def test_noisy_stdout_still_parses(self):
+        eval_file = _write_temp_evaluator(EVALUATOR_NOISY_STDOUT)
+        try:
+            evaluator = SubprocessEvaluator(_make_config(eval_file))
+            result = asyncio.run(evaluator.evaluate_program("pass"))
+            assert result.metrics["combined_score"] == 0.5
+        finally:
+            os.unlink(eval_file)
+
+
+class TestSubprocessEvaluatorIsolation:
+    def test_crash_does_not_affect_parent(self):
+        eval_file = _write_temp_evaluator(EVALUATOR_CRASH)
+        try:
+            evaluator = SubprocessEvaluator(_make_config(eval_file))
+            result = asyncio.run(evaluator.evaluate_program("x = 1"))
+            # Parent is still alive — got an error result, not a crash
+            assert result.metrics.get("error") == 0.0
+        finally:
+            os.unlink(eval_file)
+
+    def test_exception_in_evaluate_returns_error(self):
+        eval_file = _write_temp_evaluator(EVALUATOR_RETURNS_ERROR)
+        try:
+            evaluator = SubprocessEvaluator(_make_config(eval_file))
+            result = asyncio.run(evaluator.evaluate_program("x = 1"))
+            assert result.metrics.get("error") == 0.0
+        finally:
+            os.unlink(eval_file)
+
+    def test_crash_then_success(self):
+        """After a crash, subsequent evaluations still work (new process each time)."""
+        crash_file = _write_temp_evaluator(EVALUATOR_CRASH)
+        success_file = _write_temp_evaluator(EVALUATOR_SUCCESS)
+        try:
+            # First: crash
+            crash_eval = SubprocessEvaluator(_make_config(crash_file))
+            result1 = asyncio.run(crash_eval.evaluate_program("x = 1"))
+            assert result1.metrics.get("error") == 0.0
+
+            # Second: success (proves parent process is fine)
+            success_eval = SubprocessEvaluator(_make_config(success_file))
+            result2 = asyncio.run(success_eval.evaluate_program("a = 1\nb = 2\n"))
+            assert result2.metrics["combined_score"] == 0.85
+        finally:
+            os.unlink(crash_file)
+            os.unlink(success_file)
+
+
+class TestSubprocessEvaluatorTimeout:
+    def test_timeout_returns_timeout_metric(self):
+        slow_evaluator = """\
+import time
+
+def evaluate(program_path):
+    time.sleep(60)
+    return {"combined_score": 1.0}
+"""
+        eval_file = _write_temp_evaluator(slow_evaluator)
+        try:
+            evaluator = SubprocessEvaluator(_make_config(eval_file, timeout=2))
+            result = asyncio.run(evaluator.evaluate_program("x = 1"))
+            assert result.metrics.get("timeout") is True or result.metrics.get("error") == 0.0
+        finally:
+            os.unlink(eval_file)


### PR DESCRIPTION
## Summary

Adds `SubprocessEvaluator` — a new evaluator that runs each candidate in a separate
Python subprocess, providing process-level isolation without requiring Docker.

## Problem

When evaluating candidate programs that can corrupt process state (e.g. CUDA kernels with illegal
memory access, C extensions that segfault, memory corruption), the in-process
`Evaluator` allows one bad candidate to poison all subsequent evaluations. For GPU
workloads, `cudaErrorIllegalAddress` is sticky — once triggered, the CUDA context is
permanently corrupted and all further operations fail.

## Solution

`SubprocessEvaluator` provides a middle ground between `Evaluator` (fast, no isolation) and
`ContainerizedEvaluator` (full Docker):

| Evaluator | Isolation | Overhead | Setup |
|-----------|-----------|----------|-------|
| Evaluator | None | ~0ms | None |
| **SubprocessEvaluator** | **Process** | **~100-200ms** | **None** |
| ContainerizedEvaluator | Container | High | Dockerfile required |

- Each evaluate() call spawns a fresh Python subprocess
- Child process gets its own CUDA context / address space
- If a candidate crashes, only the subprocess dies
- Same evaluate(program_path) -> dict interface as Evaluator

## Usage 
set `evaluator.subprocess_isolation: true` in config YAML.

The auto-detection in create_evaluator() checks this flag after Harbor/Container detection but before falling back to in-process.

##Test
Includes 6 tests covering: successful evaluation, noisy stdout parsing, crash isolation, exception handling, crash-then-success recovery, and timeout behavior.




## Usage

```yaml
evaluator:
  subprocess_isolation: true
  evaluation_file: my_evaluator.py
  timeout: 300
