### PR TITLE
 EvoX meta-search: check LLM availability at startup and during runtime

### DIFF
--- a/skydiscover/llm/llm_pool.py
+++ b/skydiscover/llm/llm_pool.py
@@ -61,7 +61,16 @@ class LLMPool:
         return await model.generate(system_message, messages, **kwargs)
 
     async def check_availability(self, timeout: float = 15.0) -> bool:
-        """Probe the first model with a minimal request to check connectivity."""
+        """Probe the first model with a minimal request to check connectivity.
+
+        This is a representative check only: it tests the first configured
+        backend, not the entire pool.  A healthy first backend does not
+        guarantee all backends are reachable (and vice-versa).
+
+        The max_tokens=1 probe verifies endpoint connectivity and auth, not
+        generation correctness.  Reasoning models may return empty content on
+        such minimal requests without raising an error.
+        """
         try:
             model = self.models[0]
             await asyncio.wait_for(

--- a/skydiscover/llm/llm_pool.py
+++ b/skydiscover/llm/llm_pool.py
@@ -60,6 +60,18 @@ class LLMPool:
         model = self._sample_model()
         return await model.generate(system_message, messages, **kwargs)
 
+    async def check_availability(self, timeout: float = 15.0) -> bool:
+        """Probe the first model with a minimal request to check connectivity."""
+        try:
+            model = self.models[0]
+            await asyncio.wait_for(
+                model.generate("", [{"role": "user", "content": "ping"}], max_tokens=1),
+                timeout=timeout,
+            )
+            return True
+        except Exception:
+            return False
+
     async def generate_all(
         self, system_message: str, messages: List[Dict[str, Any]], **kwargs
     ) -> List[LLMResponse]:

--- a/skydiscover/search/evox/controller.py
+++ b/skydiscover/search/evox/controller.py
@@ -79,6 +79,9 @@ class CoEvolutionController(DiscoveryController):
 
         self._switch_interval = getattr(self.config.search, "switch_interval", None)
         self._stagnant_count = 0
+        self._meta_evolution_failures = 0
+        self._guide_llm_available = True
+        self._meta_llm_available = True
         self._last_tracked_best_score: Optional[float] = None
 
         self._diverge_label = ""
@@ -95,6 +98,52 @@ class CoEvolutionController(DiscoveryController):
         )
         self.search_outputs_dir = os.path.join(base_dir, "search")
         os.makedirs(self.search_outputs_dir, exist_ok=True)
+
+    async def _check_meta_llm_availability(self) -> None:
+        """Probe guide and meta-search LLM pools at startup and warn if unreachable."""
+        import asyncio
+
+        guide_pool = self.search_controller.guide_llms
+        meta_pool = self.search_controller.llms
+
+        guide_endpoint = guide_pool.models_cfg[0].api_base if guide_pool.models_cfg else "unknown"
+        meta_endpoint = meta_pool.models_cfg[0].api_base if meta_pool.models_cfg else "unknown"
+
+        guide_ok, meta_ok = await asyncio.gather(
+            guide_pool.check_availability(),
+            meta_pool.check_availability(),
+        )
+
+        self._guide_llm_available = guide_ok
+        self._meta_llm_available = meta_ok
+
+        if guide_ok and meta_ok:
+            logger.info(
+                "Meta-search LLM connectivity verified (guide: %s, meta: %s)",
+                guide_endpoint,
+                meta_endpoint,
+            )
+            return
+
+        if not guide_ok:
+            logger.warning(
+                "Guide LLM (label generation) at %s is not reachable. "
+                "Variation operator labels will fall back to generic defaults. "
+                "The meta-search can still evolve strategies, but without "
+                "problem-specific labels. To fix: set search.share_llm: true "
+                "to use the main discovery endpoint.",
+                guide_endpoint,
+            )
+
+        if not meta_ok:
+            logger.warning(
+                "Meta-search LLM (search strategy evolution) at %s is not "
+                "reachable. Search strategy evolution will be skipped; the "
+                "initial search algorithm will be used throughout the run. "
+                "Solution evolution is unaffected. To fix: set "
+                "search.share_llm: true to use the main discovery endpoint.",
+                meta_endpoint,
+            )
 
     async def run_discovery(
         self,
@@ -114,6 +163,9 @@ class CoEvolutionController(DiscoveryController):
         self.start_db_stats = self.database.get_statistics(
             improvement_threshold=self.DEFAULT_IMPROVEMENT_THRESHOLD
         )
+
+        # Check meta-search LLM availability before starting
+        await self._check_meta_llm_availability()
 
         # Set up search window and labels
         self._reset_search_window()
@@ -155,7 +207,23 @@ class CoEvolutionController(DiscoveryController):
                     logger.info(
                         f"Stagnation detected -> evolving search strategy (solution_iter={completed_solution_iter})"
                     )
-                    await self._evolve_search(completed_solution_iter)
+                    try:
+                        await self._evolve_search(completed_solution_iter)
+                    except Exception as e:
+                        # Meta-evolution is an optimization, not a correctness
+                        # requirement. If the meta-search LLM is unreachable,
+                        # keep the current search strategy and continue the run
+                        # rather than killing hours of solution evolution. Set
+                        # search.share_llm: true if the meta-search should use the
+                        # main process's (reachable) endpoint.
+                        logger.warning(
+                            "Search-strategy evolution failed (%s); continuing "
+                            "with the current strategy. Solution evolution is "
+                            "unaffected.",
+                            e,
+                            exc_info=True,
+                        )
+                        self._meta_evolution_failures += 1
 
             except Exception as e:
                 logger.error(f"Error in iteration {iteration}: {e}", exc_info=True)
@@ -169,10 +237,18 @@ class CoEvolutionController(DiscoveryController):
             await self._finalize_pending_search()
 
         logger.info(f"[SOLUTION EVOLUTION] Evolution completed: {self.database.name}")
+        if self._meta_evolution_failures:
+            logger.warning(
+                "Meta-search evolution failed %d time(s) during this run.",
+                self._meta_evolution_failures,
+            )
         return self.database.get_best_program()
 
     def _should_evolve_search(self) -> bool:
         """Check if it's time to evolve the search algorithm (stagnation-based)."""
+        if not self._meta_llm_available:
+            return False
+
         current = self._get_best_score()
 
         if self._last_tracked_best_score is None:
@@ -272,6 +348,11 @@ class CoEvolutionController(DiscoveryController):
             self._assign_labels_to_db(self.database)
             return
 
+        if not self._guide_llm_available:
+            logger.info("Skipping label generation (guide LLM unavailable at startup)")
+            self._assign_labels_to_db(self.database)
+            return
+
         db_cfg = self.config.search.database
         if not getattr(db_cfg, "auto_generate_variation_operators", True):
             from skydiscover.search.evox.utils.template import (
@@ -309,7 +390,12 @@ class CoEvolutionController(DiscoveryController):
         except Exception as e:
             self._diverge_label = ""
             self._refine_label = ""
-            logger.error(f"Label generation failed: {e}, setting labels to empty strings")
+            logger.warning(
+                "Guide LLM unreachable during label generation (%s); using "
+                "default variation operators. Meta-search evolution is "
+                "unaffected.",
+                e,
+            )
 
         self._assign_labels_to_db(self.database)
 
@@ -341,6 +427,7 @@ class CoEvolutionController(DiscoveryController):
                 result,
                 solution_iter,
             )
+            self._meta_evolution_failures += 1
             self._num_search_evolutions += 1
             return
 
@@ -364,6 +451,7 @@ class CoEvolutionController(DiscoveryController):
                 solution_iter,
                 "validation",
             )
+            self._meta_evolution_failures += 1
             self._num_search_evolutions += 1
             return
 

--- a/skydiscover/search/evox/controller.py
+++ b/skydiscover/search/evox/controller.py
@@ -348,11 +348,6 @@ class CoEvolutionController(DiscoveryController):
             self._assign_labels_to_db(self.database)
             return
 
-        if not self._guide_llm_available:
-            logger.info("Skipping label generation (guide LLM unavailable at startup)")
-            self._assign_labels_to_db(self.database)
-            return
-
         db_cfg = self.config.search.database
         if not getattr(db_cfg, "auto_generate_variation_operators", True):
             from skydiscover.search.evox.utils.template import (
@@ -365,6 +360,11 @@ class CoEvolutionController(DiscoveryController):
             logger.info(
                 "Using default variation operators (auto_generate_variation_operators=false)"
             )
+            self._assign_labels_to_db(self.database)
+            return
+
+        if not self._guide_llm_available:
+            logger.info("Skipping label generation (guide LLM unavailable at startup)")
             self._assign_labels_to_db(self.database)
             return
 

--- a/tests/search/test_meta_llm_availability.py
+++ b/tests/search/test_meta_llm_availability.py
@@ -1,0 +1,123 @@
+"""Tests for meta-search LLM availability checks."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skydiscover.config import LLMModelConfig
+from skydiscover.llm.llm_pool import LLMPool
+
+
+class TestLLMPoolCheckAvailability:
+    """Tests for LLMPool.check_availability()."""
+
+    def _make_pool(self, api_base="http://localhost:1234/v1"):
+        cfg = LLMModelConfig(
+            name="test-model",
+            api_base=api_base,
+            api_key="fake",
+            timeout=10,
+            retries=0,
+        )
+        with patch("skydiscover.llm.openai.openai.OpenAI"):
+            pool = LLMPool([cfg])
+        return pool
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_reachable(self):
+        pool = self._make_pool()
+        pool.models[0].generate = AsyncMock(return_value=MagicMock(text="ok"))
+        result = await pool.check_availability()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_unreachable(self):
+        pool = self._make_pool()
+        pool.models[0].generate = AsyncMock(side_effect=ConnectionError("refused"))
+        result = await pool.check_availability()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_timeout(self):
+        pool = self._make_pool()
+
+        async def slow_generate(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        pool.models[0].generate = slow_generate
+        result = await pool.check_availability(timeout=0.1)
+        assert result is False
+
+
+
+class TestCoEvolutionControllerAvailabilityCheck:
+    """Tests for CoEvolutionController._check_meta_llm_availability()."""
+
+    def _make_controller(self):
+        """Create a minimal CoEvolutionController without full init."""
+        from skydiscover.search.evox.controller import CoEvolutionController
+
+        controller = object.__new__(CoEvolutionController)
+        controller.search_controller = MagicMock()
+
+        guide_pool = MagicMock()
+        guide_pool.models_cfg = [MagicMock(api_base="http://guide-llm:8000/v1")]
+        meta_pool = MagicMock()
+        meta_pool.models_cfg = [MagicMock(api_base="http://meta-llm:8000/v1")]
+
+        controller.search_controller.guide_llms = guide_pool
+        controller.search_controller.llms = meta_pool
+
+        return controller
+
+    @pytest.mark.asyncio
+    async def test_both_reachable_logs_info(self, caplog):
+        import logging
+
+        controller = self._make_controller()
+        controller.search_controller.guide_llms.check_availability = AsyncMock(return_value=True)
+        controller.search_controller.llms.check_availability = AsyncMock(return_value=True)
+
+        with caplog.at_level(logging.INFO, logger="skydiscover.search.evox.controller"):
+            await controller._check_meta_llm_availability()
+
+        assert "connectivity verified" in caplog.text
+        assert "WARNING" not in caplog.text
+        assert controller._guide_llm_available is True
+        assert controller._meta_llm_available is True
+
+    @pytest.mark.asyncio
+    async def test_guide_unreachable_warns(self, caplog):
+        import logging
+
+        controller = self._make_controller()
+        controller.search_controller.guide_llms.check_availability = AsyncMock(return_value=False)
+        controller.search_controller.llms.check_availability = AsyncMock(return_value=True)
+
+        with caplog.at_level(logging.WARNING, logger="skydiscover.search.evox.controller"):
+            await controller._check_meta_llm_availability()
+
+        assert "Guide LLM (label generation)" in caplog.text
+        assert "http://guide-llm:8000/v1" in caplog.text
+        assert "share_llm: true" in caplog.text
+        assert controller._guide_llm_available is False
+        assert controller._meta_llm_available is True
+
+    @pytest.mark.asyncio
+    async def test_meta_unreachable_warns(self, caplog):
+        import logging
+
+        controller = self._make_controller()
+        controller.search_controller.guide_llms.check_availability = AsyncMock(return_value=True)
+        controller.search_controller.llms.check_availability = AsyncMock(return_value=False)
+
+        with caplog.at_level(logging.WARNING, logger="skydiscover.search.evox.controller"):
+            await controller._check_meta_llm_availability()
+
+        assert "Meta-search LLM (search strategy evolution)" in caplog.text
+        assert "http://meta-llm:8000/v1" in caplog.text
+        assert "share_llm: true" in caplog.text
+        assert controller._guide_llm_available is True
+        assert controller._meta_llm_available is False
+


### PR DESCRIPTION

Builds on #48 ("Allow EvoX meta-evolution to share LLM config with parent process").

## Summary

The EvoX co-evolution controller uses a separate LLM endpoint for meta-search (search-strategy evolution and label generation), configured via `search.yaml` (defaults to OpenAI). When this endpoint is unreachable, the run would previously fail mid-way with no upfront guidance. This PR adds proactive availability checks at startup so users get clear, actionable feedback when the meta-search LLM is unreachable, and graceful degradation if it goes down mid-run.

## Changes

- **Startup availability probe** — before the co-evolution loop begins, both the guide LLM (label generation) and meta-search LLM (strategy evolution) pools are probed with a lightweight request. Results are stored in `_guide_llm_available` / `_meta_llm_available` flags and used to short-circuit later calls that would otherwise hang.
- **Short-circuit on unavailability** — if the guide LLM is unreachable, `_generate_variation_operators()` skips the LLM call entirely (no timeout hang). If the meta-search LLM is unreachable, `_should_evolve_search()` returns `False` so evolution is never attempted.
- **Mid-run graceful degradation** — if the meta-search LLM becomes unreachable during a run, `_evolve_search` failures are caught and logged rather than crashing the entire run. The solution evolution continues unaffected with the current search strategy.
- **Accurate failure counting** — `_meta_evolution_failures` is incremented both in the outer exception handler and inside `_generate_and_validate_search_algorithm` (where most failures are handled internally without raising).
- **End-of-run summary** — reports total meta-evolution failures at the end of the run if any occurred.
- **`LLMPool.check_availability()`** — new method that sends a minimal `max_tokens=1` request to verify endpoint connectivity.

## Behavior when LLM is unavailable

| Scenario | Consequence | User sees |
|----------|-------------|-----------|
| Guide LLM unreachable at startup | Labels skipped (no timeout hang) | WARNING with endpoint + fix |
| Meta-search LLM unreachable at startup | Strategy evolution disabled (no timeout hang) | WARNING with endpoint + fix |
| Meta-search LLM fails mid-run | Current strategy kept, run continues | WARNING per failure + end-of-run summary |
| Guide LLM fails mid-run (label gen) | Empty labels, meta-search still works | WARNING |

## Test plan

- [x] 6 tests in `tests/search/test_meta_llm_availability.py` covering:
  - `LLMPool.check_availability()`: reachable, unreachable, timeout
  - `_check_meta_llm_availability()`: both OK (flags True), guide down (flag False), meta down (flag False)

