### PR TITLE
Clean up logging output: demote dev chatter from INFO to DEBUG

### DIFF
--- a/skydiscover/context_builder/default/builder.py
+++ b/skydiscover/context_builder/default/builder.py
@@ -60,7 +60,7 @@ class DefaultContextBuilder(ContextBuilder):
         """
         self.system_template_override = system_template
         self.user_template_override = user_template
-        logger.info(f"Templates set: system={system_template}, user={user_template}")
+        logger.debug(f"Templates set: system={system_template}, user={user_template}")
 
     # ------------------------------------------------------------------
     # Main Prompt Builder

--- a/skydiscover/context_builder/evox/builder.py
+++ b/skydiscover/context_builder/evox/builder.py
@@ -50,7 +50,7 @@ class EvoxContextBuilder(DefaultContextBuilder):
         summary_llm_config = config.llm.guide_models
         self.summary_llm: LLMPool = LLMPool(summary_llm_config)
         if summary_llm_config:
-            logger.info(
+            logger.debug(
                 f"Initialized guide LLM inside EvoxContextBuilder: {summary_llm_config[0].name}"
             )
 

--- a/skydiscover/context_builder/human_feedback.py
+++ b/skydiscover/context_builder/human_feedback.py
@@ -54,7 +54,7 @@ class HumanFeedbackReader:
             os.makedirs(os.path.dirname(self.path), exist_ok=True)
             with open(self.path, "w") as f:
                 f.write(_INITIAL_TEMPLATE)
-            logger.info(f"Created human feedback file: {self.path}")
+            logger.debug(f"Created human feedback file: {self.path}")
 
     def read(self) -> str:
         """
@@ -79,9 +79,9 @@ class HumanFeedbackReader:
 
         if content != self._last_content:
             if content:
-                logger.info(f"Human feedback updated ({len(content)} chars)")
+                logger.debug(f"Human feedback updated ({len(content)} chars)")
             elif self._last_content:
-                logger.info("Human feedback cleared")
+                logger.debug("Human feedback cleared")
             self._last_content = content
 
         return content
@@ -99,7 +99,7 @@ class HumanFeedbackReader:
             logger.warning(f"Invalid human feedback mode '{mode}', ignoring")
             return
         self.mode = mode
-        logger.info(f"Human feedback mode set to: {mode}")
+        logger.debug(f"Human feedback mode set to: {mode}")
 
     def apply_feedback(self, prompt: dict) -> dict:
         """Apply current feedback to a prompt dict.
@@ -135,7 +135,7 @@ class HumanFeedbackReader:
             "mode": mode,
         }
         self._history.append(entry)
-        logger.info(
+        logger.debug(
             f"Human feedback logged: iteration={iteration}, mode={mode}, "
             f"chars={len(feedback_text)}"
         )

--- a/skydiscover/evaluation/container_evaluator.py
+++ b/skydiscover/evaluation/container_evaluator.py
@@ -82,12 +82,12 @@ class ContainerizedEvaluator:
         self.llm_judge = None
         self.env_vars = dict(env_vars or {})
         if self.env_vars:
-            logger.info(
+            logger.debug(
                 f"Passing {len(self.env_vars)} environment variables to container: {list(self.env_vars.keys())}"
             )
         self.image_tag = self._build_image()
         self.container_id = self._start_container()
-        logger.info(f"ContainerizedEvaluator ready: container={self.container_id[:12]}")
+        logger.debug(f"ContainerizedEvaluator ready: container={self.container_id[:12]}")
 
     def close(self):
         """Stop and remove the persistent container."""
@@ -156,7 +156,7 @@ class ContainerizedEvaluator:
                     timeout=self.config.timeout,
                 )
                 elapsed = time.time() - start_time
-                logger.info(
+                logger.debug(
                     f"Evaluated program{label} [{mode}] in {elapsed:.2f}s:"
                     f" {format_metrics(result.metrics)}"
                 )

--- a/skydiscover/evaluation/evaluator.py
+++ b/skydiscover/evaluation/evaluator.py
@@ -50,7 +50,7 @@ class Evaluator:
         self.env_vars = dict(env_vars or {})
 
         self._load_evaluation_function()
-        logger.info(f"Initialized evaluator with {self.evaluation_file}")
+        logger.debug(f"Initialized evaluator with {self.evaluation_file}")
 
     # ------------------------------------------------------------------
     # Module loading
@@ -148,7 +148,7 @@ class Evaluator:
                         eval_result.artifacts.update(llm_result.artifacts)
 
                 elapsed = time.time() - start_time
-                logger.info(
+                logger.debug(
                     f"Evaluated program{label} in {elapsed:.2f}s: {format_metrics(eval_result.metrics)}"
                 )
                 return eval_result

--- a/skydiscover/evaluation/harbor_evaluator.py
+++ b/skydiscover/evaluation/harbor_evaluator.py
@@ -163,7 +163,7 @@ class HarborEvaluator(ContainerizedEvaluator):
             match = re.search(r"timeout_sec\s*=\s*(\d+)", text)
             if match:
                 config.timeout = int(match.group(1))
-                logger.info(f"Harbor task.toml: set evaluator timeout to {config.timeout}s")
+                logger.debug(f"Harbor task.toml: set evaluator timeout to {config.timeout}s")
         except Exception as e:
             logger.warning(f"Failed to read task.toml: {e}")
 
@@ -251,13 +251,13 @@ class HarborEvaluator(ContainerizedEvaluator):
         # Tier 1: parse solution/solve.sh (most reliable).
         path = self._extract_path_from_solve_sh()
         if path:
-            logger.info(f"Extracted solution path from solve.sh: {path}")
+            logger.debug(f"Extracted solution path from solve.sh: {path}")
             return path
 
         # Tier 2: parse instruction.md.
         path = self._extract_path_from_instruction()
         if path:
-            logger.info(f"Extracted solution path from instruction.md: {path}")
+            logger.debug(f"Extracted solution path from instruction.md: {path}")
             return path
 
         # Tier 3: default.

--- a/skydiscover/extras/external/gepa_backend.py
+++ b/skydiscover/extras/external/gepa_backend.py
@@ -162,7 +162,7 @@ def _build_gepa_config(config: Config, iterations: int):
                 provider, bare_name, _, _ = _parse_model_spec(secondary.name)
                 refiner_kwargs["refiner_lm"] = f"{provider}/{bare_name}"
 
-            logger.info(
+            logger.debug(
                 "GEPA model mapping: reflection_lm='%s', refiner_lm='%s'",
                 primary.name,
                 secondary.name,
@@ -174,7 +174,7 @@ def _build_gepa_config(config: Config, iterations: int):
                     len(config.llm.models) - 2,
                 )
         else:
-            logger.info(
+            logger.debug(
                 "GEPA model mapping: reflection_lm='%s' (also used as refiner_lm)",
                 primary.name,
             )
@@ -260,10 +260,10 @@ async def run(
             else:
                 system_prompt = (system_prompt or "") + "\n\n## Human Guidance\n" + feedback
             feedback_reader.set_current_prompt(system_prompt)
-            logger.info(
+            logger.debug(
                 f"Human feedback applied to GEPA background ({len(feedback)} chars, mode={feedback_reader.mode})"
             )
-            logger.info("Note: GEPA runs synchronously; feedback is applied once at startup.")
+            logger.debug("Note: GEPA runs synchronously; feedback is applied once at startup.")
 
     # Log to file so screen output is captured
     log_dir = os.path.join(output_dir, "logs")

--- a/skydiscover/extras/external/openevolve_backend.py
+++ b/skydiscover/extras/external/openevolve_backend.py
@@ -245,7 +245,7 @@ async def run(
                                     m.system_message = new_prompt
                             feedback_reader.set_current_prompt(new_prompt)
                             if feedback:
-                                logger.info(
+                                logger.debug(
                                     f"Human feedback injected into OpenEvolve ({len(feedback)} chars, mode={feedback_reader.mode})"
                                 )
                     except Exception:

--- a/skydiscover/extras/external/shinkaevolve_backend.py
+++ b/skydiscover/extras/external/shinkaevolve_backend.py
@@ -248,7 +248,7 @@ if __name__ == "__main__":
                                         original_prompt + "\n\n## Human Guidance\n" + feedback
                                     )
                                 feedback_reader.set_current_prompt(sampler.task_sys_msg)
-                                logger.info(
+                                logger.debug(
                                     f"Human feedback injected into ShinkaEvolve ({len(feedback)} chars, mode={feedback_reader.mode})"
                                 )
                             elif sampler and not feedback:

--- a/skydiscover/extras/monitor/__init__.py
+++ b/skydiscover/extras/monitor/__init__.py
@@ -63,13 +63,13 @@ def start_monitor(
             feedback_mode = getattr(config, "human_feedback_mode", "append")
             feedback_reader = HumanFeedbackReader(feedback_path, mode=feedback_mode)
             monitor_server.set_feedback_reader(feedback_reader)
-            logger.info("Human feedback enabled — file: %s", feedback_path)
+            logger.debug("Human feedback enabled — file: %s", feedback_path)
         except Exception as exc:
             logger.warning("Failed to set up human feedback: %s", exc)
 
         url = f"http://localhost:{monitor_server.port}/"
         print(f"\n  Live monitor: {url}\n", flush=True)
-        logger.info("Live monitor: %s", url)
+        logger.debug("Live monitor: %s", url)
 
     except Exception as exc:
         logger.warning("Failed to start monitor: %s", exc)

--- a/skydiscover/extras/monitor/server.py
+++ b/skydiscover/extras/monitor/server.py
@@ -140,7 +140,7 @@ class MonitorServer:
         self._thread.start()
         # Wait until TCP port is actually bound (up to 5s)
         self._ready_event.wait(timeout=5)
-        logger.info(f"Monitor server started → http://localhost:{self.port}/")
+        logger.debug(f"Monitor server started → http://localhost:{self.port}/")
 
     def stop(self) -> None:
         """Signal the server to stop and wait for the thread to finish."""
@@ -206,7 +206,7 @@ class MonitorServer:
                 "Click 'Refresh Summary' to generate an AI summary of the top programs."
             )
 
-        logger.info(
+        logger.debug(
             f"AI summary configured: model={model}, top_k={top_k}, "
             f"interval={interval or 'manual'}, api_key={'set' if self._summary_api_key else 'MISSING'}"
         )
@@ -428,7 +428,7 @@ class MonitorServer:
                     "human_feedback_mode": self._feedback_reader.mode,
                 }
                 await self._broadcast(json.dumps(ack))
-                logger.info(f"Human feedback set from dashboard ({len(text)} chars)")
+                logger.debug(f"Human feedback set from dashboard ({len(text)} chars)")
             else:
                 await self._ws_send(
                     writer,
@@ -451,7 +451,7 @@ class MonitorServer:
                     "human_feedback_mode": self._feedback_reader.mode,
                 }
                 await self._broadcast(json.dumps(ack))
-                logger.info("Human feedback cleared from dashboard")
+                logger.debug("Human feedback cleared from dashboard")
         elif t == "request_feedback_state":
             await self._ws_send(
                 writer,
@@ -471,7 +471,7 @@ class MonitorServer:
                     "human_feedback_mode": mode,
                 }
                 await self._broadcast(json.dumps(ack))
-                logger.info(f"Human feedback mode set to: {mode}")
+                logger.debug(f"Human feedback mode set to: {mode}")
         elif t == "request_system_prompt":
             prompt_text = ""
             if self._feedback_reader:
@@ -798,10 +798,10 @@ class MonitorServer:
             top_programs = self._get_top_k_programs()
             if not top_programs:
                 self._summary_text = "No scored programs yet. Run some iterations first."
-                logger.info("AI summary skipped: no scored programs")
+                logger.debug("AI summary skipped: no scored programs")
             else:
                 prompt_data = self._build_summary_prompt(top_programs)
-                logger.info(
+                logger.debug(
                     f"AI summary: calling {self._summary_model} with {len(top_programs)} "
                     f"top programs, api_base={self._summary_api_base}"
                 )
@@ -814,7 +814,7 @@ class MonitorServer:
                     prompt_data,
                 )
                 self._summary_text = result or "AI returned empty response."
-                logger.info(f"AI summary generated ({len(self._summary_text)} chars)")
+                logger.debug(f"AI summary generated ({len(self._summary_text)} chars)")
         except Exception as e:
             logger.warning(f"AI summary generation failed: {e}", exc_info=True)
             self._summary_text = f"Summary generation failed: {e}"

--- a/skydiscover/extras/monitor/viewer.py
+++ b/skydiscover/extras/monitor/viewer.py
@@ -230,13 +230,13 @@ def main() -> None:
         print(f"Error: no checkpoint data found in '{args.path}'")
         sys.exit(1)
 
-    logger.info(f"Loading from: {ckpt_dir}")
+    logger.debug(f"Loading from: {ckpt_dir}")
     prog_list, best_id, last_iter = load_programs(ckpt_dir)
     if not prog_list:
         print(f"Error: no programs found in '{ckpt_dir}'")
         sys.exit(1)
 
-    logger.info(f"Loaded {len(prog_list)} programs (best={best_id}, last_iter={last_iter})")
+    logger.debug(f"Loaded {len(prog_list)} programs (best={best_id}, last_iter={last_iter})")
 
     all_progs = {p["id"]: p for p in prog_list}
     monitor_programs = [_to_monitor_format(p, all_progs) for p in prog_list]

--- a/skydiscover/llm/agentic_generator.py
+++ b/skydiscover/llm/agentic_generator.py
@@ -116,7 +116,7 @@ class AgenticGenerator:
 
             if not tool_calls:
                 if text_content:
-                    logger.info(
+                    logger.debug(
                         "Agent produced text at step %d (%d files read)", step, len(files_read)
                     )
                     return text_content
@@ -140,7 +140,7 @@ class AgenticGenerator:
                     )
                     continue
 
-                logger.info(
+                logger.debug(
                     "Step %d: tool=%s args=%s",
                     step,
                     name,
@@ -211,7 +211,7 @@ class AgenticGenerator:
         except Exception as exc:
             if "unsupported" not in str(exc).lower() and "not found" not in str(exc).lower():
                 raise
-            logger.info("Chat Completions unsupported for agentic; falling back to Responses API")
+            logger.debug("Chat Completions unsupported for agentic; falling back to Responses API")
             model._use_responses_api = True
             return await self._call_llm_responses(model, system_message, conversation)
 

--- a/skydiscover/llm/llm_pool.py
+++ b/skydiscover/llm/llm_pool.py
@@ -43,7 +43,7 @@ class LLMPool:
                 logger._logged_pools = set()
             if pool_key not in logger._logged_pools:
                 parts = ", ".join(f"{c.name}={w:.2f}" for c, w in zip(models_cfg, self.weights))
-                logger.info(f"Pool weights: {parts}")
+                logger.debug(f"Pool weights: {parts}")
                 logger._logged_pools.add(pool_key)
 
     def _sample_model(self):

--- a/skydiscover/llm/openai.py
+++ b/skydiscover/llm/openai.py
@@ -106,7 +106,7 @@ class OpenAILLM(LLMInterface):
                 provider = "Mistral"
             else:
                 provider = "OpenAI"
-            logger.info(f"{provider} LLM: {self.model}")
+            logger.debug(f"{provider} LLM: {self.model}")
             logger._initialized_models.add(self.model)
 
     async def generate(
@@ -239,7 +239,7 @@ class OpenAILLM(LLMInterface):
             # Fall back transparently when Chat Completions is unsupported.
             if "unsupported" not in str(exc).lower() and "not found" not in str(exc).lower():
                 raise
-            logger.info("Chat Completions unsupported; falling back to Responses API")
+            logger.debug("Chat Completions unsupported; falling back to Responses API")
             return await self._call_api_via_responses(params)
 
     async def _call_api_via_responses(self, params: Dict[str, Any]) -> str:
@@ -334,7 +334,7 @@ class OpenAILLM(LLMInterface):
                     image_path = os.path.join(output_dir, fname)
                     with open(image_path, "wb") as f:
                         f.write(base64.b64decode(image_b64))
-                    logger.info(f"Image saved: {image_path}")
+                    logger.debug(f"Image saved: {image_path}")
 
                 return LLMResponse(text=text, image_path=image_path)
 

--- a/skydiscover/runner.py
+++ b/skydiscover/runner.py
@@ -80,7 +80,7 @@ class Runner:
         # Initialize the discovery controller
         self.discovery_controller: Optional[DiscoveryController] = None
 
-        logger.info(f"Runner ready: search={self.name}, program={self.initial_program_path}")
+        logger.debug(f"Runner ready: search={self.name}, program={self.initial_program_path}")
 
     @property
     def initial_score(self) -> Optional[float]:
@@ -235,7 +235,7 @@ class Runner:
     # ------------------------------------------------------------------
 
     async def _add_initial_program(self, start_iteration: int) -> None:
-        logger.info("Adding initial program to database")
+        logger.debug("Adding initial program to database")
         program_id = str(uuid.uuid4())
 
         initial_image_path = None
@@ -251,7 +251,7 @@ class Runner:
                     program_id=program_id,
                 )
                 initial_image_path = result.image_path
-                logger.info(f"Initial image: {initial_image_path}")
+                logger.debug(f"Initial image: {initial_image_path}")
             except Exception as e:
                 logger.warning(f"Failed to generate initial image: {e}")
 
@@ -307,7 +307,7 @@ class Runner:
 
             url = f"http://localhost:{server.port}/"
             print(f"\n  Live monitor: {url}\n", flush=True)
-            logger.info(f"Live monitor: {url}")
+            logger.debug(f"Live monitor: {url}")
             return server
         except Exception as e:
             logger.warning(f"Failed to start monitor: {e}")
@@ -327,7 +327,7 @@ class Runner:
             self.discovery_controller.feedback_reader = reader
             if monitor_server:
                 monitor_server.set_feedback_reader(reader)
-            logger.info(f"Human feedback: {path}")
+            logger.debug(f"Human feedback: {path}")
         except Exception as e:
             logger.warning(f"Failed to set up human feedback: {e}")
 
@@ -355,7 +355,7 @@ class Runner:
                 )
             except Exception:
                 logger.debug("Monitor callback failed for program %s", prog.id, exc_info=True)
-        logger.info(f"Pushed {len(self.database.programs)} existing program(s) to monitor")
+        logger.debug(f"Pushed {len(self.database.programs)} existing program(s) to monitor")
 
     def _install_signal_handlers(self) -> None:
         def on_signal(signum, frame):
@@ -425,7 +425,7 @@ class Runner:
                 )
             logger.info(f"Checkpoint {iteration}: best={format_metrics(best.metrics)}")
 
-        logger.info(f"Checkpoint saved to {checkpoint_path}")
+        logger.debug(f"Checkpoint saved to {checkpoint_path}")
 
     def _load_checkpoint(self, checkpoint_path: str) -> None:
         if not os.path.exists(checkpoint_path):
@@ -475,4 +475,4 @@ class Runner:
 
                 shutil.copy2(img, os.path.join(best_dir, "best_image" + os.path.splitext(img)[1]))
 
-        logger.info(f"Best program saved to {best_dir}")
+        logger.debug(f"Best program saved to {best_dir}")

--- a/skydiscover/search/adaevolve/controller.py
+++ b/skydiscover/search/adaevolve/controller.py
@@ -77,7 +77,7 @@ class AdaEvolveController(DiscoveryController):
         # This ensures correct behavior after checkpoint load
         if self.database.use_paradigm_breakthrough:
             model_names = ", ".join(m.name for m in self.guide_llms.models_cfg)
-            logger.info(f"Paradigm LLM: using guide_models [{model_names}]")
+            logger.debug(f"Paradigm LLM: using guide_models [{model_names}]")
 
             self.paradigm_generator = ParadigmGenerator(
                 llm_pool=self.guide_llms,
@@ -99,7 +99,7 @@ class AdaEvolveController(DiscoveryController):
         self._last_sampling_mode: Optional[str] = None
         self._last_sampling_intensity: Optional[float] = None
 
-        logger.info(
+        logger.debug(
             f"AdaEvolveController initialized "
             f"(language={self.config.language}, "
             f"paradigm_breakthrough={self.database.use_paradigm_breakthrough})"
@@ -141,7 +141,7 @@ class AdaEvolveController(DiscoveryController):
             output_dir, f"adaevolve_iteration_stats_{timestamp}.jsonl"
         )
 
-        logger.info(
+        logger.debug(
             f"AdaEvolve iteration stats will be logged to: {self._iteration_stats_log_path}"
         )
 
@@ -261,7 +261,7 @@ class AdaEvolveController(DiscoveryController):
 
         # Log final summary and stats file location
         if self._iteration_stats_log_path:
-            logger.info(f"AdaEvolve iteration stats saved to: {self._iteration_stats_log_path}")
+            logger.debug(f"AdaEvolve iteration stats saved to: {self._iteration_stats_log_path}")
 
         return self.database.get_best_program()
 
@@ -295,7 +295,7 @@ class AdaEvolveController(DiscoveryController):
                     metadata={"seeded_to_island": i},
                 )
                 self.database.add(copy, iteration=0, target_island=i)
-                logger.info(f"Seeded island {i}")
+                logger.debug(f"Seeded island {i}")
 
     async def _run_iteration(self, iteration: int, checkpoint_callback) -> None:
         """Execute one evolution iteration."""
@@ -345,7 +345,7 @@ class AdaEvolveController(DiscoveryController):
         if self.database.has_active_paradigm():
             return  # Already have paradigms to use
 
-        logger.info("Global paradigm stagnation detected, generating breakthrough ideas...")
+        logger.debug("Global paradigm stagnation detected, generating breakthrough ideas...")
 
         # Get current best program for context
         best_program = self.database.get_best_program()
@@ -372,7 +372,7 @@ class AdaEvolveController(DiscoveryController):
 
         if paradigms:
             self.database.set_paradigms(paradigms)
-            logger.info(f"Generated {len(paradigms)} breakthrough paradigms")
+            logger.debug(f"Generated {len(paradigms)} breakthrough paradigms")
         else:
             logger.warning("Failed to generate paradigms")
 
@@ -440,7 +440,7 @@ class AdaEvolveController(DiscoveryController):
                 f"{k}={v:.4f}" if isinstance(v, float) else f"{k}={v}"
                 for k, v in child.metrics.items()
             )
-            logger.info(f"Metrics: {metrics_str}")
+            logger.debug(f"Metrics: {metrics_str}")
 
         # Check for new best
         if self.database.is_multiobjective_enabled():
@@ -454,7 +454,7 @@ class AdaEvolveController(DiscoveryController):
 
         # Checkpoint callback
         if iteration > 0 and iteration % self.config.checkpoint_interval == 0:
-            logger.info(f"Checkpoint interval reached at iteration {iteration}")
+            logger.debug(f"Checkpoint interval reached at iteration {iteration}")
             self.database.log_status()
             if checkpoint_callback:
                 checkpoint_callback(iteration)

--- a/skydiscover/search/adaevolve/database.py
+++ b/skydiscover/search/adaevolve/database.py
@@ -270,7 +270,7 @@ class AdaEvolveDatabase(ProgramDatabase):
         # Last sampling mode (stashed by sample() for the controller to read)
         self._last_sampling_mode: Optional[str] = None
 
-        logger.info(
+        logger.debug(
             f"AdaEvolveDatabase initialized: "
             f"num_islands={self.num_islands}, "
             f"decay={self.decay}, "
@@ -379,7 +379,7 @@ class AdaEvolveDatabase(ProgramDatabase):
             program: The initial/seed program to copy to all islands
             iteration: Current iteration (for tracking)
         """
-        logger.info(f"Seeding all {self.num_islands} islands with initial program")
+        logger.debug(f"Seeding all {self.num_islands} islands with initial program")
 
         for island_idx in range(self.num_islands):
             if island_idx == 0:
@@ -399,7 +399,7 @@ class AdaEvolveDatabase(ProgramDatabase):
                 )
                 self.add(copy, iteration=iteration, target_island=island_idx)
 
-        logger.info(
+        logger.debug(
             f"All islands seeded. Island sizes: "
             f"{[self.get_island_size(i) for i in range(self.num_islands)]}"
         )
@@ -792,7 +792,7 @@ class AdaEvolveDatabase(ProgramDatabase):
         # Periodic migration (can be disabled for ablation)
         if self.use_migration and iteration > 0 and iteration % self.migration_interval == 0:
             self._migrate()
-            logger.info(f"Migration completed at iteration {iteration}")
+            logger.debug(f"Migration completed at iteration {iteration}")
 
     def _migrate(self) -> None:
         """
@@ -1290,7 +1290,7 @@ class AdaEvolveDatabase(ProgramDatabase):
 
             json.dump(metadata, f, indent=2, cls=SafeJSONEncoder)
 
-        logger.info(f"Saved AdaEvolve state to {save_path}")
+        logger.debug(f"Saved AdaEvolve state to {save_path}")
 
     def load(self, path: str) -> None:
         """
@@ -1335,7 +1335,7 @@ class AdaEvolveDatabase(ProgramDatabase):
 
         # Handle dynamic island count - may need to expand
         if saved_num_islands > self.num_islands:
-            logger.info(
+            logger.debug(
                 f"Checkpoint has {saved_num_islands} islands, " f"expanding from {self.num_islands}"
             )
             self._expand_to_island_count(saved_num_islands, metadata)
@@ -1401,7 +1401,7 @@ class AdaEvolveDatabase(ProgramDatabase):
                         self.islands[island_idx].append(self.programs[pid])
 
         self._invalidate_global_pareto_cache()
-        logger.info(
+        logger.debug(
             f"Loaded AdaEvolve state from {path}: "
             f"{self.num_islands} islands, {len(self.programs)} programs, "
             f"unified_archive={self.use_unified_archive}"
@@ -1431,7 +1431,7 @@ class AdaEvolveDatabase(ProgramDatabase):
                     self.islands[island_idx].append(program)
 
         self._invalidate_global_pareto_cache()
-        logger.info(f"Distributed {len(programs_list)} programs across {self.num_islands} islands")
+        logger.debug(f"Distributed {len(programs_list)} programs across {self.num_islands} islands")
 
     def _expand_to_island_count(self, target_count: int, metadata: Dict[str, Any]) -> None:
         """
@@ -2033,7 +2033,7 @@ class AdaEvolveDatabase(ProgramDatabase):
         if global_productivity >= self.spawn_productivity_threshold:
             return False
 
-        logger.info(
+        logger.debug(
             f"Spawn conditions met: global_productivity={global_productivity:.3f} "
             f"< threshold={self.spawn_productivity_threshold}, "
             f"islands={self.num_islands}/{self.max_islands}"
@@ -2097,7 +2097,7 @@ class AdaEvolveDatabase(ProgramDatabase):
         self.num_islands += 1
         self.last_spawn_iteration = self._iteration_count
 
-        logger.info(
+        logger.debug(
             f"Spawned new island {new_island_idx} with config '{config_name}' "
             f"(total islands: {self.num_islands}/{self.max_islands})"
         )

--- a/skydiscover/search/adaevolve/paradigm/generator.py
+++ b/skydiscover/search/adaevolve/paradigm/generator.py
@@ -194,14 +194,14 @@ class ParadigmGenerator:
                     )
                     last_error = "Parse failure"
                     if attempt < MAX_RETRIES - 1:
-                        logger.info(f"Retrying paradigm generation in {backoff:.1f}s...")
+                        logger.debug(f"Retrying paradigm generation in {backoff:.1f}s...")
                         await asyncio.sleep(backoff)
                         backoff *= BACKOFF_MULTIPLIER
                     continue
 
-                logger.info(f"Generated {len(paradigms)} paradigms:")
+                logger.debug(f"Generated {len(paradigms)} paradigms:")
                 for i, p in enumerate(paradigms):
-                    logger.info(
+                    logger.debug(
                         f"  [{i+1}] {p.get('idea', 'N/A')} (approach: {p.get('approach_type', 'N/A')})"
                     )
                 return paradigms
@@ -213,7 +213,7 @@ class ParadigmGenerator:
                 )
 
                 if attempt < MAX_RETRIES - 1:
-                    logger.info(f"Retrying in {backoff:.1f}s...")
+                    logger.debug(f"Retrying in {backoff:.1f}s...")
                     await asyncio.sleep(backoff)
                     backoff *= BACKOFF_MULTIPLIER
 

--- a/skydiscover/search/adaevolve/paradigm/tracker.py
+++ b/skydiscover/search/adaevolve/paradigm/tracker.py
@@ -158,7 +158,7 @@ class ParadigmTracker:
 
         # Log paradigm usage with idea
         paradigm = self.active_paradigms[self.current_paradigm_index]
-        logger.info(
+        logger.debug(
             f"Using paradigm {self.current_paradigm_index + 1}/{len(self.active_paradigms)} "
             f"({current_uses + 1}/{self.max_paradigm_uses}): {paradigm.get('idea', 'N/A')}"
         )
@@ -190,7 +190,7 @@ class ParadigmTracker:
         self.best_score_at_paradigm_gen = current_best_score
         self.best_score_during_paradigm = current_best_score
 
-        logger.info(f"Set {len(paradigms)} new paradigms (best score: {current_best_score:.6f})")
+        logger.debug(f"Set {len(paradigms)} new paradigms (best score: {current_best_score:.6f})")
 
     def clear_paradigms(self) -> None:
         """
@@ -228,7 +228,7 @@ class ParadigmTracker:
                 return True
 
         # All paradigms exhausted
-        logger.info("All paradigms exhausted, will archive on next check")
+        logger.debug("All paradigms exhausted, will archive on next check")
         return False
 
     def _archive_current_paradigms(self) -> None:
@@ -265,14 +265,14 @@ class ParadigmTracker:
 
         # Log archived paradigms with outcomes
         if self.active_paradigms:
-            logger.info(
+            logger.debug(
                 f"Archived {len(self.active_paradigms)} paradigms (improvement: {score_improvement:+.6f}):"
             )
             for idx, paradigm in enumerate(self.active_paradigms):
                 uses = self.paradigm_usage_counts.get(idx, 0)
                 if uses > 0:
                     outcome = "SUCCESS" if score_improvement > 0.001 else "FAILED"
-                    logger.info(f"  [{outcome}] {paradigm.get('idea', 'N/A')} (uses: {uses})")
+                    logger.debug(f"  [{outcome}] {paradigm.get('idea', 'N/A')} (uses: {uses})")
 
     # =========================================================================
     # Feedback for Generator

--- a/skydiscover/search/base_database.py
+++ b/skydiscover/search/base_database.py
@@ -335,7 +335,7 @@ class ProgramDatabase(ABC):
             score_str = format_metrics(best_program.metrics)
         else:
             score_str = "N/A"
-        logger.info(
+        logger.debug(
             f"Database has {len(self.programs)} programs, best program score is {score_str}"
         )
 

--- a/skydiscover/search/beam_search/database.py
+++ b/skydiscover/search/beam_search/database.py
@@ -76,7 +76,7 @@ class BeamSearchDatabase(ProgramDatabase):
         # Now call super().__init__() which may trigger load()
         super().__init__(name, config)
 
-        logger.info(
+        logger.debug(
             f"BeamSearchDatabase initialized: width={self.beam_width}, "
             f"strategy={self.selection_strategy}, diversity_weight={self.diversity_weight}"
         )
@@ -326,7 +326,7 @@ class BeamSearchDatabase(ProgramDatabase):
         top_programs = self.get_top_programs(n + 1)
         other_context_programs = [p for p in top_programs if p.id != parent.id][:n]
 
-        logger.info(
+        logger.debug(
             f"Beam search: selected parent {parent.id} (depth={self.depth.get(parent.id, 0)}, "
             f"score={self._get_program_score(parent):.4f}), "
             f"beam_size={len(self.beam)}, other_context_programs={len(other_context_programs)}"
@@ -504,7 +504,7 @@ class BeamSearchDatabase(ProgramDatabase):
     def log_status(self) -> None:
         """Log the status of the beam search database."""
         stats = self.get_search_stats()
-        logger.info(
+        logger.debug(
             f"BeamSearchDatabase status: {stats['total_programs']} programs, "
             f"beam_size={stats['beam_size']}, max_depth={stats['max_depth_reached']}, "
             f"expansions={stats['total_expansions']}"
@@ -513,9 +513,9 @@ class BeamSearchDatabase(ProgramDatabase):
         # Log beam contents
         if self.beam:
             beam_progs = self.get_beam_programs()
-            logger.info("Current beam:")
+            logger.debug("Current beam:")
             for i, prog in enumerate(beam_progs[:5]):  # Show top 5
-                logger.info(
+                logger.debug(
                     f"  {i+1}. {prog.id}: score={self._get_program_score(prog):.4f}, "
                     f"depth={self.depth.get(prog.id, 0)}"
                 )
@@ -566,7 +566,7 @@ class BeamSearchDatabase(ProgramDatabase):
         with open(os.path.join(save_path, "metadata.json"), "w") as f:
             json.dump(metadata, f, indent=2)
 
-        logger.info(
+        logger.debug(
             f"Saved BeamSearchDatabase with {len(self.programs)} programs, "
             f"beam_size={len(self.beam)} to {save_path}"
         )
@@ -599,7 +599,7 @@ class BeamSearchDatabase(ProgramDatabase):
             saved_stats = metadata.get("stats", {})
             self.stats.update(saved_stats)
 
-            logger.info(
+            logger.debug(
                 f"Loaded metadata: last_iteration={self.last_iteration}, "
                 f"beam_size={len(self.beam)}"
             )
@@ -622,7 +622,7 @@ class BeamSearchDatabase(ProgramDatabase):
         # Validate and reconstruct beam if needed
         self._validate_and_reconstruct_beam()
 
-        logger.info(f"Loaded BeamSearchDatabase with {len(self.programs)} programs from {path}")
+        logger.debug(f"Loaded BeamSearchDatabase with {len(self.programs)} programs from {path}")
         self.log_status()
 
     def _validate_and_reconstruct_beam(self) -> None:
@@ -648,15 +648,15 @@ class BeamSearchDatabase(ProgramDatabase):
         # Reconstruct depth for programs missing it
         missing_depth = [pid for pid in self.programs if pid not in self.depth]
         if missing_depth:
-            logger.info(f"Reconstructing depth for {len(missing_depth)} programs")
+            logger.debug(f"Reconstructing depth for {len(missing_depth)} programs")
             self._reconstruct_depths()
 
         # If beam is empty but we have programs, reconstruct beam from top programs
         if not self.beam and self.programs:
-            logger.info("Beam is empty, reconstructing from top programs")
+            logger.debug("Beam is empty, reconstructing from top programs")
             top_programs = self.get_top_programs(self.beam_width)
             self.beam = {p.id for p in top_programs}
-            logger.info(f"Reconstructed beam with {len(self.beam)} programs")
+            logger.debug(f"Reconstructed beam with {len(self.beam)} programs")
 
     def _reconstruct_depths(self) -> None:
         """

--- a/skydiscover/search/best_of_n/database.py
+++ b/skydiscover/search/best_of_n/database.py
@@ -29,7 +29,7 @@ class BestOfNDatabase(ProgramDatabase):
         self.current_parent_id: Optional[str] = None
         self.parent_iteration_count: int = 0
 
-        logger.info(f"BestOfNDatabase initialized: N={self.n}")
+        logger.debug(f"BestOfNDatabase initialized: N={self.n}")
 
     def add(self, program: Program, iteration: Optional[int] = None, **kwargs) -> str:
         """
@@ -94,7 +94,7 @@ class BestOfNDatabase(ProgramDatabase):
             self.current_parent_id = parent.id
             self.parent_iteration_count = 0
 
-            logger.info(
+            logger.debug(
                 f"Best-of-N: sampled new parent {parent.id} (score={safe_score(parent):.4f})"
             )
         else:

--- a/skydiscover/search/default_discovery_controller.py
+++ b/skydiscover/search/default_discovery_controller.py
@@ -97,7 +97,7 @@ class DiscoveryController:
             from skydiscover.llm.agentic_generator import AgenticGenerator
 
             self.agentic_generator = AgenticGenerator(self.llms, self.config.agentic)
-            logger.info(f"Agentic mode enabled (codebase: {self.config.agentic.codebase_root})")
+            logger.debug(f"Agentic mode enabled (codebase: {self.config.agentic.codebase_root})")
 
         self.num_context_programs = controller_input.config.search.num_context_programs
 
@@ -109,7 +109,7 @@ class DiscoveryController:
         # the LLM knows what problem to solve (especially for from-scratch).
         self._inject_evaluator_context()
 
-        logger.info(
+        logger.debug(
             f"DiscoveryController initialized: num_context_programs={self.num_context_programs}"
         )
 
@@ -279,7 +279,7 @@ class DiscoveryController:
         pending: set = set()
         last_result: Optional[SerializableResult] = None
 
-        logger.info(
+        logger.debug(
             f"Parallel discovery: up to {max_parallel} iterations in flight "
             f"({start_iteration}..{total_iterations - 1})"
         )
@@ -502,7 +502,7 @@ class DiscoveryController:
                 )
 
                 if failed_attempts:
-                    logger.info(
+                    logger.debug(
                         f"Retry {retry + 1}/{retry_times}: rebuilding prompt with {len(failed_attempts)} failed attempt(s)"
                     )
 
@@ -961,7 +961,7 @@ class DiscoveryController:
 
         if iteration > 0 and iteration % self.config.checkpoint_interval == 0:
             if verbose:
-                logger.info(f"[CHECKPOINT] Checkpoint interval reached at iteration {iteration}")
+                logger.debug(f"Checkpoint interval reached at iteration {iteration}")
 
             self.database.log_status()
             if checkpoint_callback:
@@ -973,7 +973,7 @@ class DiscoveryController:
                     f"{k}={v:.4f}" if isinstance(v, (int, float)) else f"{k}={v}"
                     for k, v in child_program.metrics.items()
                 )
-                logger.info(f"Metrics: {metrics_str}")
+                logger.debug(f"Metrics: {metrics_str}")
 
             if not hasattr(self, "_warned_about_combined_score"):
                 self._warned_about_combined_score = False

--- a/skydiscover/search/evox/controller.py
+++ b/skydiscover/search/evox/controller.py
@@ -109,7 +109,7 @@ class CoEvolutionController(DiscoveryController):
 
         if self._switch_interval is None:
             self._switch_interval = max(1, int(max_iterations * self.DEFAULT_SWITCH_RATIO))
-            logger.info(f"Switch if {self._switch_interval} iterations of stagnation detected")
+            logger.debug(f"Switch if {self._switch_interval} iterations of stagnation detected")
 
         self.start_db_stats = self.database.get_statistics(
             improvement_threshold=self.DEFAULT_IMPROVEMENT_THRESHOLD
@@ -152,7 +152,7 @@ class CoEvolutionController(DiscoveryController):
 
                 # Co-evolve search strategy if needed (skip on final iteration)
                 if iteration < self.total_solution_iterations and self._should_evolve_search():
-                    logger.info(
+                    logger.debug(
                         f"Stagnation detected -> evolving search strategy (solution_iter={completed_solution_iter})"
                     )
                     await self._evolve_search(completed_solution_iter)
@@ -281,7 +281,7 @@ class CoEvolutionController(DiscoveryController):
 
             self._diverge_label = DEFAULT_DIVERGE_TEMPLATE
             self._refine_label = DEFAULT_REFINE_TEMPLATE
-            logger.info(
+            logger.debug(
                 "Using default variation operators (auto_generate_variation_operators=false)"
             )
             self._assign_labels_to_db(self.database)
@@ -296,14 +296,14 @@ class CoEvolutionController(DiscoveryController):
             problem_dir = Path(self.evaluation_file).parent if self.evaluation_file else None
             label_llms = self.search_controller.guide_llms
             model_names = ", ".join(m.name for m in label_llms.models_cfg)
-            logger.info(f"Label generation: using guide_model = [{model_names}]")
+            logger.debug(f"Label generation: using guide_model = [{model_names}]")
             self._diverge_label, self._refine_label = await generate_variation_operators(
                 system_message,
                 evaluator_code,
                 problem_dir=problem_dir,
                 llm_pool=label_llms,
             )
-            logger.info(
+            logger.debug(
                 f"Generated variation operator labels ({len(self._diverge_label)}/{len(self._refine_label)} chars)"
             )
         except Exception as e:
@@ -425,7 +425,7 @@ class CoEvolutionController(DiscoveryController):
             self.database = new_db
             if self.evaluator.llm_judge:
                 self.evaluator.llm_judge.database = new_db
-            logger.info(
+            logger.debug(
                 f"Switched to search algorithm {search_program_id} ({migrated_count} programs migrated)"
             )
 
@@ -568,7 +568,7 @@ class CoEvolutionController(DiscoveryController):
 
         is_new_best = self._best_search_score is not None and score > self._best_search_score
         if is_new_best:
-            logger.info(
+            logger.debug(
                 f"New best search score: {score:.6f} (+{score - self._best_search_score:.6f})"
             )
         if is_new_best or self._best_search_score is None:
@@ -576,16 +576,16 @@ class CoEvolutionController(DiscoveryController):
         return is_new_best
 
     def _log_coevolution_setup(self, db_cfg) -> None:
-        logger.info("=" * 70)
-        logger.info("[EVOX CO-EVOLUTION SETUP]")
-        logger.info("-" * 70)
-        logger.info(f"  [SOLUTION EVOLUTION]")
-        logger.info(f"    Initial search strategy file : {db_cfg.database_file_path}")
-        logger.info(f"    Solution database class      : {self.database.__class__.__name__}")
-        logger.info(f"  [META EVOLUTION OF SEARCH STRATEGY]")
-        logger.info(
+        logger.debug("=" * 70)
+        logger.debug("[EVOX CO-EVOLUTION SETUP]")
+        logger.debug("-" * 70)
+        logger.debug(f"  [SOLUTION EVOLUTION]")
+        logger.debug(f"    Initial search strategy file : {db_cfg.database_file_path}")
+        logger.debug(f"    Solution database class      : {self.database.__class__.__name__}")
+        logger.debug(f"  [META EVOLUTION OF SEARCH STRATEGY]")
+        logger.debug(
             f"    Search strategy database class: {self.search_controller.database.__class__.__name__}"
         )
-        logger.info(f"    Search strategy evaluator     : {db_cfg.evaluation_file}")
-        logger.info(f"    Search strategy config        : {db_cfg.config_path}")
-        logger.info("=" * 70)
+        logger.debug(f"    Search strategy evaluator     : {db_cfg.evaluation_file}")
+        logger.debug(f"    Search strategy config        : {db_cfg.config_path}")
+        logger.debug("=" * 70)

--- a/skydiscover/search/evox/utils/coevolve_logging.py
+++ b/skydiscover/search/evox/utils/coevolve_logging.py
@@ -61,7 +61,7 @@ async def log_search_algorithm_generated(
     )
 
     iteration_dir = os.path.join(outputs_dir, f"iteration_{iteration}")
-    logger.info(
+    logger.debug(
         f"New search algorithm generated (iteration {iteration}) - "
         f"saved to {os.path.abspath(iteration_dir)} (score pending)"
     )
@@ -129,7 +129,7 @@ async def save_search_algorithm(
                 labels_text += f"  {line}\n"
             with open(labels_path, "w") as f:
                 f.write(labels_text)
-            logger.info(
+            logger.debug(
                 f"Saved labels to {labels_path} ({len(diverge_label)}/{len(refine_label)} chars)"
             )
         except Exception as e:

--- a/skydiscover/search/evox/utils/search_scorer.py
+++ b/skydiscover/search/evox/utils/search_scorer.py
@@ -68,7 +68,7 @@ class LogWindowScorer:
         log_weight = 1.0 + math.log(1.0 + max(0.0, start))
         combined_score = improvement * log_weight / math.sqrt(horizon_int)
 
-        logger.info(
+        logger.debug(
             f"Search strategy score: combined={combined_score:.6f}, "
             f"improvement={improvement:.6f}, start={start:.6f}, "
             f"end={running_best:.6f}, horizon={horizon_int}"

--- a/skydiscover/search/evox/utils/variation_operator_generator.py
+++ b/skydiscover/search/evox/utils/variation_operator_generator.py
@@ -288,7 +288,7 @@ def get_available_packages(problem_dir=None) -> list:
                             continue
                         packages.append(line)
                     if packages:
-                        logger.info(f"Read {len(packages)} packages from {requirements_path}")
+                        logger.debug(f"Read {len(packages)} packages from {requirements_path}")
                         return packages
                 except Exception as e:
                     logger.warning(f"Could not read {requirements_path} ({e})")
@@ -311,7 +311,7 @@ def get_available_packages(problem_dir=None) -> list:
                     continue
                 packages.append(line)
             if packages:
-                logger.info(f"Read {len(packages)} packages from {requirements_path}")
+                logger.debug(f"Read {len(packages)} packages from {requirements_path}")
                 return packages
         except Exception as e:
             logger.warning(f"Could not read requirements.txt ({e}), trying pyproject.toml")

--- a/skydiscover/search/gepa_native/controller.py
+++ b/skydiscover/search/gepa_native/controller.py
@@ -73,7 +73,7 @@ class GEPANativeController(DiscoveryController):
         self._merge_attempts_used: int = 0
         self._merge_pairs_tried: Set[Tuple[str, str]] = set()
 
-        logger.info(
+        logger.debug(
             f"GEPANativeController initialized: "
             f"acceptance_gating={self.acceptance_gating}, "
             f"use_merge={self.use_merge}, "
@@ -258,7 +258,7 @@ class GEPANativeController(DiscoveryController):
             child = Program.from_dict(result.child_program_dict)
             self.database.add_rejected(child)
 
-            logger.info(
+            logger.debug(
                 f"Iteration {iteration}: REJECTED child "
                 f"(child_score={child_score:.4f} <= parent_score={parent_score:.4f})"
             )
@@ -312,7 +312,7 @@ class GEPANativeController(DiscoveryController):
         score_a = get_score(prog_a.metrics)
         score_b = get_score(prog_b.metrics)
 
-        logger.info(
+        logger.debug(
             f"Iteration {iteration}: Attempting merge "
             f"(stagnation={self._iterations_without_improvement}, "
             f"attempt={self._merge_attempts_used}/{self.max_merge_attempts}, "
@@ -354,7 +354,7 @@ class GEPANativeController(DiscoveryController):
             return
 
         merged_score = get_score(eval_result.metrics)
-        logger.info(
+        logger.debug(
             f"Iteration {iteration}: Merge completed"
             f" (llm: {llm_generation_time:.2f}s,"
             f" eval: {eval_time:.2f}s)"
@@ -389,7 +389,7 @@ class GEPANativeController(DiscoveryController):
                 responses=[llm_response],  # already str via .text extraction above
             )
 
-            logger.info(
+            logger.debug(
                 f"Merge ACCEPTED: score={merged_score:.4f} "
                 f"(>= max({score_a:.4f}, {score_b:.4f}))"
             )
@@ -409,7 +409,7 @@ class GEPANativeController(DiscoveryController):
                         f"Monitor callback failed: {e}"
                     )  # Never crash discovery due to monitor
         else:
-            logger.info(
+            logger.debug(
                 f"Merge REJECTED: score={merged_score:.4f} " f"< max({score_a:.4f}, {score_b:.4f})"
             )
             # Stagnation counter NOT reset on rejected merge

--- a/skydiscover/search/openevolve_native/database.py
+++ b/skydiscover/search/openevolve_native/database.py
@@ -154,7 +154,7 @@ class OpenEvolveNativeDatabase(ProgramDatabase):
         if random_seed is not None:
             random.seed(random_seed)
 
-        logger.info(
+        logger.debug(
             "OpenEvolveNativeDatabase: %d islands, pop=%d, archive=%d, "
             "features=%s, bins=%d, migration_interval=%d, migration_rate=%.2f",
             self.num_islands,
@@ -662,7 +662,7 @@ class OpenEvolveNativeDatabase(ProgramDatabase):
             old_id = self.best_program_id
             self.best_program_id = program.id
             if "combined_score" in program.metrics and "combined_score" in current_best.metrics:
-                logger.info(
+                logger.debug(
                     "New best program %s replaces %s (%.4f -> %.4f)",
                     program.id,
                     old_id,
@@ -716,7 +716,7 @@ class OpenEvolveNativeDatabase(ProgramDatabase):
             self.archive.discard(pid)
 
         self._cleanup_stale_island_bests()
-        logger.info(
+        logger.debug(
             "Population limit: removed %d, now %d",
             len(to_remove),
             len(self.programs),
@@ -750,7 +750,7 @@ class OpenEvolveNativeDatabase(ProgramDatabase):
     def _migrate_programs(self) -> None:
         if self.num_islands < 2:
             return
-        logger.info("Performing migration between islands")
+        logger.debug("Performing migration between islands")
 
         for i, island in enumerate(self.islands):
             if not island:
@@ -805,7 +805,7 @@ class OpenEvolveNativeDatabase(ProgramDatabase):
                     )
 
         self.last_migration_generation = max(self.island_generations)
-        logger.info(
+        logger.debug(
             "Migration completed at generation %d",
             self.last_migration_generation,
         )
@@ -951,7 +951,7 @@ class OpenEvolveNativeDatabase(ProgramDatabase):
                 best = avg = 0.0
             cells = len(self.island_feature_maps[i]) if i < len(self.island_feature_maps) else 0
             gen = self.island_generations[i] if i < len(self.island_generations) else 0
-            logger.info(
+            logger.debug(
                 "Island %d: %d programs, %d cells, gen=%d, best=%.4f, avg=%.4f%s",
                 i,
                 len(progs),

--- a/skydiscover/search/registry.py
+++ b/skydiscover/search/registry.py
@@ -93,7 +93,7 @@ def get_program(
     search_type = config.search.type
 
     if search_type == "evox" and getattr(config.search.database, "database_file_path", None):
-        logger.info(f"Using search strategy from: {config.search.database.database_file_path}")
+        logger.debug(f"Using search strategy from: {config.search.database.database_file_path}")
         _, program_class = load_database_from_file(config.search.database.database_file_path)
         return program_class(
             id=initial_program_id,

--- a/skydiscover/search/utils/checkpoint_manager.py
+++ b/skydiscover/search/utils/checkpoint_manager.py
@@ -98,7 +98,7 @@ class CheckpointManager:
         with open(os.path.join(save_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
 
-        logger.info(f"[CHECKPOINT] Saved database with {len(programs)} programs to {save_path}")
+        logger.debug(f"Saved database with {len(programs)} programs to {save_path}")
 
     def load(self, path: str) -> Tuple[Dict[str, Program], Optional[str], int]:
         """
@@ -130,7 +130,7 @@ class CheckpointManager:
             best_program_id = metadata.get("best_program_id")
             last_iteration = metadata.get("last_iteration", 0)
 
-            logger.info(f"Loaded database metadata with last_iteration={last_iteration}")
+            logger.debug(f"Loaded database metadata with last_iteration={last_iteration}")
 
         # Load programs
         programs_dir = os.path.join(path, "programs")
@@ -147,7 +147,7 @@ class CheckpointManager:
                     except Exception as e:
                         logger.warning(f"Error loading program {program_file}: {str(e)}")
 
-        logger.info(f"Loaded database with {len(programs)} programs from {path}")
+        logger.debug(f"Loaded database with {len(programs)} programs from {path}")
 
         return programs, best_program_id, last_iteration
 

--- a/skydiscover/search/utils/logging_utils.py
+++ b/skydiscover/search/utils/logging_utils.py
@@ -44,13 +44,20 @@ class _ConsoleFilter(logging.Filter):
 
 
 def setup_search_logging(log_level: str, log_dir: str, name: str) -> None:
-    """Configure root logger with a timestamped file handler and a console handler."""
+    """Configure root logger with a timestamped file handler and a console handler.
+
+    The file handler always captures DEBUG+, while the console handler
+    respects *log_level* so the terminal stays clean by default.
+    """
     os.makedirs(log_dir, exist_ok=True)
     root = logging.getLogger()
-    root.setLevel(getattr(logging, log_level))
+    root.setLevel(logging.DEBUG)
+
+    console_level = getattr(logging, log_level)
 
     log_file = os.path.join(log_dir, f"{name}_{time.strftime('%Y%m%d_%H%M%S')}.log")
     fh = logging.FileHandler(log_file)
+    fh.setLevel(logging.DEBUG)
     fh.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
     root.addHandler(fh)
 
@@ -59,8 +66,9 @@ def setup_search_logging(log_level: str, log_dir: str, name: str) -> None:
         for h in root.handlers
     ):
         ch = logging.StreamHandler()
+        ch.setLevel(console_level)
         ch.setFormatter(_ConsoleFormatter())
         ch.addFilter(_ConsoleFilter())
         root.addHandler(ch)
 
-    logging.getLogger(__name__).info(f"Logging to {log_file}")
+    logging.getLogger(__name__).debug(f"Logging to {log_file}")


### PR DESCRIPTION
## Summary

- Demotes ~80 internal/setup `logger.info` calls to `logger.debug` across 33 files
- Keeps only user-facing progress messages at INFO level: iteration completions, best scores, shutdowns, checkpoints, and long-running operations (Docker builds, container stops)
- All detail remains available via `--log-level DEBUG`

### What stays at INFO (visible by default)
- Iteration progress (`Iteration X: Program Y completed in Zs`)
- New best solution found
- Discovery completed / shutdown requested
- Checkpoint summaries
- Resume from checkpoint
- Docker/Harbor image builds, container stops

### What moved to DEBUG (hidden by default)
- Setup/init details (model names, controller params, database config)
- Per-iteration metric dumps
- Internal algorithm state (island seeding, paradigm generation, migration)
- File paths (checkpoint paths, stats log paths)
- LLM API fallback info
- EvoX co-evolution setup banner

## Test plan

- [x] All 192 existing tests pass
- [x] All modified files compile without errors
- [x] Verified no user-facing progress messages were accidentally demoted

Addresses #40