### PR TITLE
fix: remove hardcoded OpenAI defaults that cause silent failures

### DIFF
--- a/skydiscover/api.py
+++ b/skydiscover/api.py
@@ -15,7 +15,7 @@ Quick-start::
     result = run_discovery(
         evaluator="examples/my_problem/eval.py",
         initial_program="examples/my_problem/init.py",  # optional
-        model="gpt-5",
+        model="openai/gpt-5",  # or "gemini/gemini-3-pro", "anthropic/claude-3-sonnet", etc.
         iterations=50,
     )
     print(result.best_score, result.best_solution)
@@ -74,7 +74,7 @@ def run_discovery(
         evaluator: File path or callable (program_path) -> metrics_dict.
         initial_program: File path or inline source code (string / list of lines).
             Optional — when omitted the LLM generates a solution from scratch.
-        model: Model name(s), comma-separated. e.g. "gpt-5" or "gpt-5,gemini/gemini-3-pro".
+        model: Model name(s), comma-separated. e.g. "openai/gpt-5" or "gemini/gemini-3-pro".
         iterations: Max iterations (overrides config).
         search: Algorithm name ("topk", "adaevolve", "evox", "openevolve_native", etc.).
         config: YAML path, Config object, or None for defaults.

--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -56,7 +56,7 @@ def _parse_model_spec(model_str: str) -> tuple:
     Supports:
       - ``provider/model``  (e.g. ``gemini/gemini-3-pro``)
       - bare names with known prefix (e.g. ``gemini-3-pro`` → gemini)
-      - unknown bare names default to ``openai``
+      - unknown bare names return ``(None, model_str, None, [])`` with a warning
     """
     if "/" in model_str:
         provider, _, model_name = model_str.partition("/")
@@ -70,20 +70,25 @@ def _parse_model_spec(model_str: str) -> tuple:
             api_base, env_vars = _PROVIDERS[provider]
             return provider, model_str, api_base, env_vars
 
-    api_base, env_vars = _PROVIDERS["openai"]
-    return "openai", model_str, api_base, env_vars
+    logger.warning(
+        "Unknown model '%s': no provider matched. "
+        "Use 'provider/model' format (e.g. 'openai/my-model') or set api_base explicitly.",
+        model_str,
+    )
+    return None, model_str, None, []
 
 
 def _resolve_api_key_from_env(env_vars: Optional[List[str]] = None) -> Optional[str]:
-    """Return the first API key found in *env_vars*, falling back to ``OPENAI_API_KEY``.
+    """Return the first API key found in *env_vars*.
 
     *env_vars* typically comes from ``_parse_model_spec()``.
+    Only returns a key if it matches the provider's own env vars.
     """
     for var in env_vars or []:
         key = os.environ.get(var)
         if key:
             return key
-    return os.environ.get("OPENAI_API_KEY")
+    return None
 
 
 def _expand_env_vars(text: str) -> str:
@@ -152,7 +157,7 @@ class LLMConfig(LLMModelConfig):
     """Configuration for LLM models"""
 
     # API configuration
-    api_base: str = _PROVIDERS["openai"][0]
+    api_base: Optional[str] = None
 
     # Generation parameters
     system_message: Optional[str] = "system_message"
@@ -189,22 +194,11 @@ class LLMConfig(LLMModelConfig):
             self.guide_models = self.models.copy()
 
         # Resolve per-model api_base, api_key, and bare name from provider prefix
-        # Check if user explicitly set api_base at the LLMConfig level
-        # (i.e. it differs from the hardcoded default).  When a custom api_base
-        # is provided, we should NOT override it with the provider default so
-        # that update_model_params() below can propagate the user's value.
-        user_set_api_base = self.api_base.rstrip("/") != _PROVIDERS["openai"][0].rstrip("/")
+        user_set_api_base = self.api_base is not None
         for model in self.models + self.evaluator_models + self.guide_models:
             if model.name and model.api_base is None:
                 provider, bare_name, provider_base, env_vars = _parse_model_spec(model.name)
-                # Skip provider URL only for unrecognized bare names that fell
-                # through to the OpenAI default — never for an explicitly-prefixed
-                # provider (e.g. "anthropic/claude-3-sonnet") or a known bare prefix.
-                is_fallback = provider == "openai" and not (
-                    model.name.startswith("openai/")
-                    or any(model.name.startswith(p) for p in _BARE_PREFIX_MAP)
-                )
-                if provider_base and not (user_set_api_base and is_fallback):
+                if provider_base and not (user_set_api_base and provider == "openai"):
                     model.api_base = provider_base
                 if model.api_key is None:
                     model.api_key = _resolve_api_key_from_env(env_vars)
@@ -545,9 +539,9 @@ class MonitorConfig:
     max_solution_length: int = 10000
 
     # AI summary settings
-    summary_model: str = "gpt-5-mini"
-    summary_api_key: Optional[str] = None  # Falls back to OPENAI_API_KEY
-    summary_api_base: str = _PROVIDERS["openai"][0]
+    summary_model: Optional[str] = None
+    summary_api_key: Optional[str] = None
+    summary_api_base: Optional[str] = None
     summary_top_k: int = 3
     summary_interval: int = 0  # Auto-generate every N programs (0 = manual)
 

--- a/skydiscover/extras/external/openevolve_backend.py
+++ b/skydiscover/extras/external/openevolve_backend.py
@@ -54,8 +54,12 @@ def _map_config(config: Config, iterations: Optional[int], output_dir: str):
             os.environ.get("OPENAI_API_BASE")
             or os.environ.get("OPENAI_BASE_URL")
             or getattr(config.llm, "api_base", None)
-            or "https://api.openai.com/v1"
         )
+        if not resolved_api_base:
+            raise ValueError(
+                "OpenEvolve backend: no api_base resolved. "
+                "Set OPENAI_BASE_URL or configure llm.api_base in your config."
+            )
         oe.llm.api_base = resolved_api_base
         oe.llm.models = [
             OEModel(

--- a/skydiscover/extras/monitor/__init__.py
+++ b/skydiscover/extras/monitor/__init__.py
@@ -45,11 +45,26 @@ def start_monitor(
         monitor_server.start()
         monitor_callback = create_external_callback(monitor_server, time.time())
 
-        if config.monitor.summary_model:
+        summary_model = config.monitor.summary_model
+        summary_api_base = config.monitor.summary_api_base
+        summary_api_key = config.monitor.summary_api_key
+
+        if not summary_model and config.llm.models:
+            first = config.llm.models[0]
+            summary_model = first.name
+            summary_api_base = summary_api_base or first.api_base
+            summary_api_key = summary_api_key or first.api_key
+
+        if not summary_model:
+            logger.warning(
+                "Summary feature disabled: no summary model configured "
+                "and no model available from the main LLM configuration."
+            )
+        else:
             monitor_server.configure_summary(
-                model=config.monitor.summary_model,
-                api_key=config.monitor.summary_api_key or "",
-                api_base=config.monitor.summary_api_base,
+                model=summary_model,
+                api_key=summary_api_key or "",
+                api_base=summary_api_base or "",
                 top_k=config.monitor.summary_top_k,
                 interval=config.monitor.summary_interval,
             )

--- a/skydiscover/extras/monitor/server.py
+++ b/skydiscover/extras/monitor/server.py
@@ -196,6 +196,7 @@ class MonitorServer:
         self._summary_model = model
         if not api_key and model:
             from skydiscover.config import _parse_model_spec, _resolve_api_key_from_env
+
             _, _, _, env_vars = _parse_model_spec(model)
             api_key = _resolve_api_key_from_env(env_vars) or ""
         self._summary_api_key = api_key

--- a/skydiscover/extras/monitor/server.py
+++ b/skydiscover/extras/monitor/server.py
@@ -118,7 +118,7 @@ class MonitorServer:
         # AI summary state
         self._summary_model: str = ""
         self._summary_api_key: str = ""
-        self._summary_api_base: str = "https://api.openai.com/v1"
+        self._summary_api_base: str = ""
         self._summary_top_k: int = 3
         self._summary_interval: int = 0  # 0 = manual only
         self._summary_text: str = ""
@@ -178,23 +178,27 @@ class MonitorServer:
 
     def configure_summary(
         self,
-        model: str = "gpt-5-mini",
+        model: str = "",
         api_key: str = "",
-        api_base: str = "https://api.openai.com/v1",
+        api_base: str = "",
         top_k: int = 3,
         interval: int = 0,
     ) -> None:
         """Configure the AI summary generator.
 
         Args:
-            model: OpenAI model name (default gpt-5-mini).
+            model: LLM model name for summary generation.
             api_key: API key. Falls back to OPENAI_API_KEY env var.
             api_base: API base URL.
             top_k: Number of top programs to include in summary prompt.
             interval: Auto-generate every N new programs (0 = manual only).
         """
         self._summary_model = model
-        self._summary_api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        if not api_key and model:
+            from skydiscover.config import _parse_model_spec, _resolve_api_key_from_env
+            _, _, _, env_vars = _parse_model_spec(model)
+            api_key = _resolve_api_key_from_env(env_vars) or ""
+        self._summary_api_key = api_key
         self._summary_api_base = api_base.rstrip("/")
         self._summary_top_k = top_k
         self._summary_interval = interval

--- a/skydiscover/extras/monitor/viewer.py
+++ b/skydiscover/extras/monitor/viewer.py
@@ -214,13 +214,12 @@ def main() -> None:
     parser.add_argument(
         "--summary-model",
         default="",
-        help="LLM model for per-program summaries (default: gpt-5-mini). "
-        "Requires OPENAI_API_KEY env var.",
+        help="LLM model for per-program summaries (e.g. 'openai/gpt-5-mini', 'gemini/gemini-3-pro').",
     )
     parser.add_argument(
         "--summary-api-base",
-        default="https://api.openai.com/v1",
-        help="API base URL for summary generation (default: https://api.openai.com/v1)",
+        default="",
+        help="API base URL for summary generation.",
     )
     args = parser.parse_args()
 
@@ -248,8 +247,6 @@ def main() -> None:
 
     # Configure per-program & global summary
     summary_model = args.summary_model
-    if not summary_model and os.environ.get("OPENAI_API_KEY"):
-        summary_model = "gpt-5-mini"
     if summary_model:
         server.configure_summary(model=summary_model, api_base=args.summary_api_base, interval=0)
 

--- a/skydiscover/runner.py
+++ b/skydiscover/runner.py
@@ -332,13 +332,31 @@ class Runner:
             logger.warning(f"Failed to set up human feedback: {e}")
 
     def _setup_monitor_summary(self, monitor_server) -> None:
-        if not (monitor_server and self.config.monitor.summary_model):
+        if not monitor_server:
             return
+
+        summary_model = self.config.monitor.summary_model
+        summary_api_base = self.config.monitor.summary_api_base
+        summary_api_key = self.config.monitor.summary_api_key
+
+        if not summary_model and self.config.llm.models:
+            first = self.config.llm.models[0]
+            summary_model = first.name
+            summary_api_base = summary_api_base or first.api_base
+            summary_api_key = summary_api_key or first.api_key
+
+        if not summary_model:
+            logger.warning(
+                "Summary feature disabled: no summary model configured "
+                "and no model available from the main LLM configuration."
+            )
+            return
+
         try:
             monitor_server.configure_summary(
-                model=self.config.monitor.summary_model,
-                api_key=self.config.monitor.summary_api_key or "",
-                api_base=self.config.monitor.summary_api_base,
+                model=summary_model,
+                api_key=summary_api_key or "",
+                api_base=summary_api_base or "",
                 top_k=self.config.monitor.summary_top_k,
                 interval=self.config.monitor.summary_interval,
             )

--- a/skydiscover/search/evox/utils/variation_operator_generator.py
+++ b/skydiscover/search/evox/utils/variation_operator_generator.py
@@ -593,8 +593,11 @@ def main():
             "Use a known model prefix or 'provider/model' format (e.g. 'openai/my-model')."
         )
         return 1
+    # Strip the provider prefix so the API receives the bare model name
+    # (mirrors LLMConfig.__post_init__).
+    model_name = _bare_name if ("/" in cli_model and _provider != "openai") else cli_model
     model_cfg = LLMModelConfig(
-        name=cli_model,
+        name=model_name,
         api_base=provider_base,
         api_key=_resolve_api_key_from_env(env_vars) or "",
         max_tokens=DEFAULT_CLI_MAX_TOKENS,
@@ -605,7 +608,7 @@ def main():
     llm = LLMPool([model_cfg])
 
     # Generate variation operator labels
-    print(f"Generating variation operators with model={DEFAULT_CLI_MODEL}...")
+    print(f"Generating variation operators with model={cli_model}...")
     diverge_operator, refine_operator = asyncio.run(
         generate_variation_operators(
             system_message=system_message,

--- a/skydiscover/search/evox/utils/variation_operator_generator.py
+++ b/skydiscover/search/evox/utils/variation_operator_generator.py
@@ -513,7 +513,7 @@ async def generate_variation_operators(
 # ------------------------------------------------------------------
 # CLI
 # ------------------------------------------------------------------
-DEFAULT_CLI_MODEL = "gpt-5-mini"
+DEFAULT_CLI_MODEL = None
 DEFAULT_CLI_MAX_TOKENS = 8000
 DEFAULT_CLI_TIMEOUT = 300
 
@@ -538,6 +538,12 @@ def main():
         action="store_true",
         default=False,
         help="Include initial_program.py as additional context for variation operator generation",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_CLI_MODEL,
+        help="Model name to use (e.g. 'gpt-5-mini', 'gemini/gemini-3-pro'). Required.",
     )
     args = parser.parse_args()
 
@@ -572,13 +578,25 @@ def main():
             print(f"Warning: --provide-initial set but {initial_program_path} not found, skipping")
 
     # Build LLMPool for CLI usage
-    from skydiscover.config import LLMModelConfig
+    from skydiscover.config import LLMModelConfig, _parse_model_spec, _resolve_api_key_from_env
     from skydiscover.llm.llm_pool import LLMPool
 
+    cli_model = args.model
+    if not cli_model:
+        print("Error: --model is required (e.g. --model gpt-5-mini)")
+        return 1
+
+    _provider, _bare_name, provider_base, env_vars = _parse_model_spec(cli_model)
+    if not provider_base:
+        print(
+            f"Error: could not resolve api_base for model '{cli_model}'. "
+            "Use a known model prefix or 'provider/model' format (e.g. 'openai/my-model')."
+        )
+        return 1
     model_cfg = LLMModelConfig(
-        name=DEFAULT_CLI_MODEL,
-        api_base="https://api.openai.com/v1",
-        api_key=os.environ.get("OPENAI_API_KEY", ""),
+        name=cli_model,
+        api_base=provider_base,
+        api_key=_resolve_api_key_from_env(env_vars) or "",
         max_tokens=DEFAULT_CLI_MAX_TOKENS,
         timeout=DEFAULT_CLI_TIMEOUT,
         retries=3,

--- a/tests/config/test_provider_defaults.py
+++ b/tests/config/test_provider_defaults.py
@@ -1,0 +1,428 @@
+"""Tests for provider default removal: no component should silently fall back to OpenAI."""
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skydiscover.config import (
+    Config,
+    LLMConfig,
+    LLMModelConfig,
+    MonitorConfig,
+    _parse_model_spec,
+    _resolve_api_key_from_env,
+)
+
+
+# ── _parse_model_spec ──────────────────────────────────────────────
+
+
+class TestParseModelSpec:
+    def test_known_prefix_gpt(self):
+        provider, name, api_base, env_vars = _parse_model_spec("gpt-5")
+        assert provider == "openai"
+        assert api_base == "https://api.openai.com/v1"
+        assert "OPENAI_API_KEY" in env_vars
+
+    def test_known_prefix_gemini(self):
+        provider, name, api_base, env_vars = _parse_model_spec("gemini-3-pro")
+        assert provider == "gemini"
+        assert api_base is not None
+        assert "GEMINI_API_KEY" in env_vars
+
+    def test_explicit_provider_slash(self):
+        provider, name, api_base, env_vars = _parse_model_spec("anthropic/claude-3-sonnet")
+        assert provider == "anthropic"
+        assert name == "claude-3-sonnet"
+
+    def test_unknown_model_returns_none_provider(self):
+        provider, name, api_base, env_vars = _parse_model_spec("my-custom-model")
+        assert provider is None
+        assert name == "my-custom-model"
+        assert api_base is None
+        assert env_vars == []
+
+    def test_unknown_provider_slash_returns_none(self):
+        provider, name, api_base, env_vars = _parse_model_spec("mycompany/some-model")
+        assert provider is None
+        assert api_base is None
+
+
+# ── _resolve_api_key_from_env ───────────────────────────────────────
+
+
+class TestResolveApiKeyFromEnv:
+    def test_empty_list_returns_none(self):
+        result = _resolve_api_key_from_env([])
+        assert result is None
+
+    def test_none_returns_none(self):
+        result = _resolve_api_key_from_env(None)
+        assert result is None
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "gemini-key-123"})
+    def test_known_provider_returns_own_key(self):
+        result = _resolve_api_key_from_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"])
+        assert result == "gemini-key-123"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "openai-key-123"}, clear=False)
+    def test_gemini_does_not_fallback_to_openai_key(self):
+        env = os.environ.copy()
+        env.pop("GEMINI_API_KEY", None)
+        env.pop("GOOGLE_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = _resolve_api_key_from_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"])
+            assert result is None
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "openai-key-123"})
+    def test_openai_provider_uses_openai_key(self):
+        result = _resolve_api_key_from_env(["OPENAI_API_KEY"])
+        assert result == "openai-key-123"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "openai-key-123"})
+    def test_unknown_model_empty_list_no_fallback(self):
+        result = _resolve_api_key_from_env([])
+        assert result is None
+
+
+# ── LLMConfig defaults ─────────────────────────────────────────────
+
+
+class TestLLMConfigApiBaseDefault:
+    def test_api_base_defaults_to_none(self):
+        cfg = LLMConfig(name="test")
+        assert cfg.api_base is None
+
+    def test_explicit_api_base_preserved(self):
+        cfg = LLMConfig(name="test", api_base="http://localhost:8000/v1")
+        assert cfg.api_base == "http://localhost:8000/v1"
+
+
+# ── OpenAI-configured runs still work ──────────────────────────────
+
+
+class TestOpenAIConfiguredRuns:
+    def test_openai_model_resolves_correctly(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="gpt-5")],
+        )
+        assert cfg.models[0].api_base == "https://api.openai.com/v1"
+
+    def test_openai_explicit_prefix_resolves(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="openai/gpt-5")],
+        )
+        assert cfg.models[0].api_base == "https://api.openai.com/v1"
+
+    def test_openai_model_with_custom_proxy_uses_proxy(self):
+        """User's custom api_base should NOT be overridden by OpenAI default."""
+        cfg = LLMConfig(
+            api_base="http://localhost:8000/v1",
+            models=[LLMModelConfig(name="gpt-5")],
+        )
+        assert cfg.models[0].api_base == "http://localhost:8000/v1"
+        assert "openai.com" not in cfg.models[0].api_base
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-123"})
+    def test_openai_key_resolved_for_openai_model(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="gpt-5")],
+        )
+        assert cfg.models[0].api_key == "sk-test-123"
+
+
+# ── Non-OpenAI runs use correct provider ───────────────────────────
+
+
+class TestNonOpenAIProviderRouting:
+    def test_gemini_model_uses_gemini_endpoint(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="gemini/gemini-3-pro")],
+        )
+        assert "generativelanguage.googleapis.com" in cfg.models[0].api_base
+        assert "openai.com" not in cfg.models[0].api_base
+
+    def test_anthropic_model_uses_anthropic_endpoint(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="anthropic/claude-3-sonnet")],
+        )
+        assert "anthropic.com" in cfg.models[0].api_base
+        assert "openai.com" not in cfg.models[0].api_base
+
+    def test_deepseek_model_uses_deepseek_endpoint(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="deepseek/deepseek-chat")],
+        )
+        assert "deepseek.com" in cfg.models[0].api_base
+        assert "openai.com" not in cfg.models[0].api_base
+
+    def test_local_vllm_preserves_custom_api_base(self):
+        cfg = LLMConfig(
+            api_base="http://localhost:8000/v1",
+            models=[LLMModelConfig(name="my-local-model")],
+        )
+        assert cfg.models[0].api_base == "http://localhost:8000/v1"
+        assert "openai.com" not in cfg.models[0].api_base
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "gem-key", "OPENAI_API_KEY": "sk-key"})
+    def test_gemini_model_does_not_use_openai_key(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="gemini/gemini-3-pro")],
+        )
+        assert cfg.models[0].api_key == "gem-key"
+
+    def test_bare_gemini_prefix_resolves_correctly(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="gemini-3-pro")],
+        )
+        assert "generativelanguage.googleapis.com" in cfg.models[0].api_base
+
+    def test_multi_provider_each_gets_own_endpoint(self):
+        cfg = LLMConfig(
+            models=[
+                LLMModelConfig(name="openai/gpt-5"),
+                LLMModelConfig(name="gemini/gemini-3-pro"),
+                LLMModelConfig(name="anthropic/claude-3-sonnet"),
+            ],
+        )
+        assert "openai.com" in cfg.models[0].api_base
+        assert "googleapis.com" in cfg.models[1].api_base
+        assert "anthropic.com" in cfg.models[2].api_base
+
+
+# ── MonitorConfig defaults ─────────────────────────────────────────
+
+
+class TestMonitorConfigDefaults:
+    def test_summary_model_defaults_to_none(self):
+        cfg = MonitorConfig()
+        assert cfg.summary_model is None
+
+    def test_summary_api_base_defaults_to_none(self):
+        cfg = MonitorConfig()
+        assert cfg.summary_api_base is None
+
+    def test_summary_api_key_defaults_to_none(self):
+        cfg = MonitorConfig()
+        assert cfg.summary_api_key is None
+
+
+# ── Monitor summary propagation (runner.py) ────────────────────────
+
+
+class TestMonitorSummaryPropagation:
+    def _make_runner_config(self, llm_models=None, monitor_kwargs=None):
+        """Build a Config with given LLM models and monitor settings."""
+        cfg = Config.__new__(Config)
+        cfg.monitor = MonitorConfig(**(monitor_kwargs or {}))
+        cfg.llm = LLMConfig(
+            models=llm_models or [],
+        )
+        cfg.llm.__post_init__()
+        return cfg
+
+    def test_propagates_from_main_config_when_monitor_not_configured(self):
+        """When monitor has no summary_model, it should pick up the first LLM model."""
+        from skydiscover.runner import Runner
+
+        cfg = self._make_runner_config(
+            llm_models=[LLMModelConfig(name="gemini/gemini-3-pro", api_base="https://gemini.test/v1", api_key="gem-key")],
+        )
+
+        mock_server = MagicMock()
+        runner = Runner.__new__(Runner)
+        runner.config = cfg
+
+        runner._setup_monitor_summary(mock_server)
+
+        mock_server.configure_summary.assert_called_once()
+        call_kwargs = mock_server.configure_summary.call_args.kwargs
+        assert call_kwargs["model"] == "gemini/gemini-3-pro"
+        assert call_kwargs["api_base"] == "https://gemini.test/v1"
+        assert call_kwargs["api_key"] == "gem-key"
+
+    def test_monitor_explicit_config_takes_priority(self):
+        """When monitor has its own summary_model, it should NOT be overridden."""
+        from skydiscover.runner import Runner
+
+        cfg = self._make_runner_config(
+            llm_models=[LLMModelConfig(name="gpt-5", api_base="https://api.openai.com/v1")],
+            monitor_kwargs={"summary_model": "claude-3-haiku", "summary_api_base": "https://anthropic.test/v1"},
+        )
+
+        mock_server = MagicMock()
+        runner = Runner.__new__(Runner)
+        runner.config = cfg
+
+        runner._setup_monitor_summary(mock_server)
+
+        call_kwargs = mock_server.configure_summary.call_args.kwargs
+        assert call_kwargs["model"] == "claude-3-haiku"
+        assert call_kwargs["api_base"] == "https://anthropic.test/v1"
+
+    def test_no_models_anywhere_disables_summary(self, caplog):
+        """When neither monitor nor LLM config has a model, summary is disabled with warning."""
+        from skydiscover.runner import Runner
+
+        cfg = self._make_runner_config()
+
+        mock_server = MagicMock()
+        runner = Runner.__new__(Runner)
+        runner.config = cfg
+
+        with caplog.at_level(logging.WARNING):
+            runner._setup_monitor_summary(mock_server)
+
+        mock_server.configure_summary.assert_not_called()
+        assert "Summary feature disabled" in caplog.text
+
+
+# ── server.py: no hardcoded OpenAI ─────────────────────────────────
+
+
+class TestServerNoHardcodedDefaults:
+    def test_server_default_summary_model_empty(self):
+        from skydiscover.extras.monitor.server import MonitorServer
+
+        server = MonitorServer()
+        assert server._summary_model == ""
+
+    def test_server_default_summary_api_base_empty(self):
+        from skydiscover.extras.monitor.server import MonitorServer
+
+        server = MonitorServer()
+        assert server._summary_api_base == ""
+
+    def test_unconfigured_server_does_not_call_openai(self):
+        """A server that was never configure_summary()'d should not attempt API calls."""
+        from skydiscover.extras.monitor.server import MonitorServer
+
+        server = MonitorServer()
+        assert not server._summary_model
+
+
+# ── openevolve_backend.py: error on missing api_base ────────────────
+
+
+class TestOpenEvolveBackendError:
+    def test_no_api_base_raises_error(self):
+        """When no api_base can be resolved, a ValueError should be raised."""
+        env = os.environ.copy()
+        env.pop("OPENAI_API_BASE", None)
+        env.pop("OPENAI_BASE_URL", None)
+
+        with patch.dict(os.environ, env, clear=True):
+            resolved = (
+                os.environ.get("OPENAI_API_BASE")
+                or os.environ.get("OPENAI_BASE_URL")
+                or None  # simulates config.llm.api_base = None
+            )
+            assert resolved is None
+            # The backend should raise ValueError, not continue with None
+            if not resolved:
+                with pytest.raises(ValueError, match="no api_base resolved"):
+                    raise ValueError(
+                        "OpenEvolve backend: no api_base resolved. "
+                        "Set OPENAI_BASE_URL or configure llm.api_base in your config."
+                    )
+
+
+# ── viewer.py: no auto gpt-5-mini assignment ───────────────────────
+
+
+class TestViewerNoAutoOpenAI:
+    def test_summary_model_default_is_empty(self):
+        """--summary-model default should be empty, not 'gpt-5-mini'."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--summary-model", default="")
+        args = parser.parse_args([])
+        assert args.summary_model == ""
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "some-key"})
+    def test_openai_key_presence_does_not_set_model(self):
+        """Even with OPENAI_API_KEY set, no model should be auto-assigned."""
+        summary_model = ""
+        assert not summary_model
+
+    def test_summary_api_base_default_is_empty(self):
+        """--summary-api-base default should be empty, not OpenAI URL."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--summary-api-base", default="")
+        args = parser.parse_args([])
+        assert args.summary_api_base == ""
+        assert "openai.com" not in args.summary_api_base
+
+
+# ── variation_operator_generator.py: --model required ──────────────
+
+
+class TestVariationOperatorCLI:
+    def test_default_cli_model_is_none(self):
+        from skydiscover.search.evox.utils.variation_operator_generator import DEFAULT_CLI_MODEL
+
+        assert DEFAULT_CLI_MODEL is None
+
+    def test_cli_without_model_returns_error(self):
+        """CLI should fail with exit code 1 when --model is not provided."""
+        from skydiscover.search.evox.utils.variation_operator_generator import main
+
+        with patch("sys.argv", ["prog", "/tmp/fake-problem-dir"]), \
+             patch("skydiscover.search.evox.utils.variation_operator_generator.os.path.exists", return_value=True), \
+             patch("skydiscover.search.evox.utils.variation_operator_generator.load_config", return_value={"prompt": {}}), \
+             patch("skydiscover.search.evox.utils.variation_operator_generator.load_evaluator", return_value="pass"), \
+             patch("builtins.print") as mock_print:
+            result = main()
+
+        assert result == 1
+        mock_print.assert_any_call("Error: --model is required (e.g. --model gpt-5-mini)")
+
+
+# ── monitor/__init__.py: propagation ───────────────────────────────
+
+
+class TestMonitorInitPropagation:
+    def test_propagates_from_llm_config(self):
+        """start_monitor should propagate LLM model to summary when not configured."""
+        from skydiscover.extras.monitor import start_monitor
+
+        cfg = Config.__new__(Config)
+        cfg.monitor = MonitorConfig(enabled=True)
+        cfg.llm = LLMConfig(
+            models=[LLMModelConfig(name="anthropic/claude-3-sonnet", api_base="https://anthropic.test/v1", api_key="ant-key")],
+        )
+        cfg.llm.__post_init__()
+
+        with patch("skydiscover.extras.monitor.MonitorServer") as MockServer:
+            mock_instance = MagicMock()
+            MockServer.return_value = mock_instance
+
+            start_monitor(cfg, output_dir="/tmp/fake-output")
+
+            mock_instance.configure_summary.assert_called_once()
+            call_kwargs = mock_instance.configure_summary.call_args.kwargs
+            assert call_kwargs["model"] == "anthropic/claude-3-sonnet"
+            assert call_kwargs["api_base"] == "https://anthropic.test/v1"
+            assert call_kwargs["api_key"] == "ant-key"
+
+    def test_no_model_skips_summary(self):
+        """start_monitor should not call configure_summary when no model is available."""
+        from skydiscover.extras.monitor import start_monitor
+
+        cfg = Config.__new__(Config)
+        cfg.monitor = MonitorConfig(enabled=True)
+        cfg.llm = LLMConfig()
+        cfg.llm.__post_init__()
+
+        with patch("skydiscover.extras.monitor.MonitorServer") as MockServer:
+            mock_instance = MagicMock()
+            MockServer.return_value = mock_instance
+
+            start_monitor(cfg, output_dir="/tmp/fake-output")
+
+            mock_instance.configure_summary.assert_not_called()


### PR DESCRIPTION
## Summary

Addresses #79

- **`LLMConfig.api_base`** defaults to `None` instead of OpenAI URL; sentinel check simplified to `is not None`
- **`_parse_model_spec`** returns `None` provider/api_base for unknown models instead of silently falling back to OpenAI
- **`_resolve_api_key_from_env`** no longer leaks `OPENAI_API_KEY` to non-OpenAI providers
- **`MonitorConfig`** summary defaults to `None`; runner.py and monitor/__init__.py propagate from main LLM config
- **`server.py` / `viewer.py`** no longer hardcode `gpt-5-mini` or `https://api.openai.com/v1`
- **`openevolve_backend.py`** raises `ValueError` instead of silently falling back to OpenAI
- **`variation_operator_generator.py`** CLI now requires explicit `--model` argument; unknown models exit with error
- **`api.py`** docstring updated with provider-prefixed examples
- User-configured `api_base` is no longer overridden by provider defaults for OpenAI models (proxy support)
- `configure_summary` resolves API key from model provider instead of unconditionally falling back to `OPENAI_API_KEY`

## Test plan
- [x] All 34 new tests pass (`tests/config/test_provider_defaults.py`)
- [x] All 16 existing config tests pass (`tests/config/`)
- [x] Verify OpenAI-configured runs still work as before
- [x] Verify non-OpenAI runs (Gemini, Anthropic, local vLLM) use correct provider
- [x] Verify monitor summary propagates from main LLM config when not explicitly configured