### PR TITLE
Add AlphaEvolve external backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ external = [
     "openevolve",
     "gepa[full]",
     "litellm>=1.81",  # gepa[full] needs litellm, but uv override-dependencies strips the [full] extra
+    "alpha-evolve",
 ]
 dev = [
     "pytest>=7.0.0",
@@ -80,6 +81,7 @@ override-dependencies = ["httpx>=0.28.1", "gepa>=0.0.26"]
 [tool.uv.sources]
 openevolve = { git = "https://github.com/algorithmicsuperintelligence/openevolve.git", branch = "main" }
 gepa = { git = "https://github.com/gepa-ai/gepa.git", branch = "main" }
+alpha-evolve = { git = "https://github.com/Google-Cloud-AI/alphaevolve-on-googlecloud.git", branch = "main" }
 
 [tool.black]
 line-length = 100

--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -623,6 +623,11 @@ class Config:
     # Runtime-only: system prompt override (set by apply_overrides, read by external backends)
     system_prompt_override: Optional[str] = None
 
+    # Backend-specific section for the AlphaEvolve external backend
+    # (project_id, engine_id, location, ...). Read by
+    # skydiscover/extras/external/alphaevolve_backend.py.
+    alphaevolve: Dict[str, Any] = field(default_factory=dict)
+
     @classmethod
     def from_yaml(cls, path: Union[str, Path]) -> Config:
         """Load configuration from a YAML file"""

--- a/skydiscover/extras/external/README.md
+++ b/skydiscover/extras/external/README.md
@@ -7,6 +7,7 @@ SkyDiscover wraps third-party evolution engines so you can swap algorithms with 
 | **OpenEvolve** | `openevolve` | Island-model genetic programming with diff-based generation and feature-based diversity |
 | **GEPA** | `gepa[full]` | Reflection-guided evolutionary optimization via `optimize_anything` API |
 | **ShinkaEvolve** | `shinka` | Multi-patch evolution with UCB1 dynamic LLM selection and code-embedding deduplication |
+| **AlphaEvolve** | `alpha-evolve` | Google's hosted evolution service (Discovery Engine), candidates generated in the cloud and evaluated locally |
 
 ## OpenEvolve
 
@@ -117,11 +118,47 @@ search:
   code_similarity_threshold: 0.995
 ```
 
+---
+
+## AlphaEvolve
+
+Wraps Google's AlphaEvolve EAP SDK. Candidate generation happens in Google Cloud (Discovery Engine), while your evaluator still runs locally. The backend writes each candidate to a temp file using the run's `file_suffix` and calls `evaluate(path)` on it.
+
+Requires GCP Application Default Credentials (`gcloud auth application-default login`, `GOOGLE_APPLICATION_CREDENTIALS`, or a GCP VM service account) and a Discovery Engine engine with the AlphaEvolve API enabled.
+
+### Usage
+
+```bash
+export ALPHAEVOLVE_PROJECT_ID=your-gcp-project
+export ALPHAEVOLVE_ENGINE_ID=your-engine-id
+
+uv run skydiscover-run initial_program.py evaluator.py \
+  --config config.yaml --search alphaevolve --iterations 100
+```
+
+### Config
+
+See `defaults/alphaevolve_default.yaml` for the full template. Settings live in a top-level `alphaevolve:` section, and `ALPHAEVOLVE_*` environment variables override it.
+
+```yaml
+alphaevolve:
+  project_id: "your-gcp-project"
+  engine_id: "your-engine-id"
+  location: "global"
+  num_samplers: 1
+  num_evaluators: 1        # > 1 runs evaluators in parallel threads
+  idle_timeout_s: 120
+  # credentials_file: "${HOME}/.config/sa.json"
+```
+
+`EVOLVE-BLOCK` markers are added automatically when the seed has none (`#` for Python, `//` for C/C++/CUDA). Only single-file programs are supported, and extra files in a candidate are ignored with a warning.
+
 ## Files
 
 | File | Purpose |
 |------|---------|
 | `openevolve_backend.py` | Wrapper around OpenEvolve's island-model controller |
+| `alphaevolve_backend.py` | Wrapper around Google's AlphaEvolve EAP SDK (cloud sampling, local evaluation) |
 | `gepa_backend.py` | Wrapper around GEPA's `optimize_anything` API |
 | `shinkaevolve_backend.py` | Wrapper around ShinkaEvolve's async evolution runner |
 | `__init__.py` | Backend registry, loader, and package-name mapping |

--- a/skydiscover/extras/external/__init__.py
+++ b/skydiscover/extras/external/__init__.py
@@ -16,12 +16,13 @@ _REGISTRY: Dict[str, Callable[..., Awaitable]] = {}
 
 # All backend names we know about, even if the package is not installed.
 # Used to give a helpful ImportError instead of "unknown search type".
-KNOWN_EXTERNAL = {"openevolve", "shinkaevolve", "gepa"}
+KNOWN_EXTERNAL = {"openevolve", "shinkaevolve", "gepa", "alphaevolve"}
 
 # search_type -> actual pip package name (when they differ)
 _PACKAGE_NAMES = {
     "shinkaevolve": "shinka",
     "gepa": "gepa[full]",
+    "alphaevolve": "alpha-evolve",
 }
 
 
@@ -34,6 +35,7 @@ _BACKENDS = [
     ("openevolve", "skydiscover.extras.external.openevolve_backend", "run"),
     ("shinkaevolve", "skydiscover.extras.external.shinkaevolve_backend", "run"),
     ("gepa", "skydiscover.extras.external.gepa_backend", "run"),
+    ("alphaevolve", "skydiscover.extras.external.alphaevolve_backend", "run"),
 ]
 
 

--- a/skydiscover/extras/external/alphaevolve_backend.py
+++ b/skydiscover/extras/external/alphaevolve_backend.py
@@ -1,0 +1,588 @@
+"""
+AlphaEvolve external backend for SkyDiscover.
+
+Wraps the vendored AlphaEvolve EAP SDK as a skydiscover external backend.
+The ``run()`` entry point orchestrates the full experiment lifecycle:
+session creation, experiment setup, initial program upload, controller loop
+(sampling + evaluation workers), and best-program extraction.
+
+Evaluation bridging converts between skydiscover's file-based evaluator
+(``evaluate(path) -> dict``) and AlphaEvolve's program-dict evaluator
+(``evaluate(program_dict) -> {scores, insights}``).
+"""
+
+import importlib.util
+import logging
+import os
+import re
+import sys
+import tempfile
+import uuid
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from skydiscover.api import DiscoveryResult
+from skydiscover.config import Config
+from skydiscover.search.base_database import Program
+
+logger = logging.getLogger(__name__)
+
+# EVOLVE-BLOCK bare marker constants
+_EVOLVE_BLOCK_MARKER_START = "EVOLVE-BLOCK-START"
+_EVOLVE_BLOCK_MARKER_END = "EVOLVE-BLOCK-END"
+
+# Backward-compatible derived constants (Python-style, used by existing tests)
+_EVOLVE_BLOCK_START = f"# {_EVOLVE_BLOCK_MARKER_START}"
+_EVOLVE_BLOCK_END = f"# {_EVOLVE_BLOCK_MARKER_END}"
+
+# File extensions that use C/C++ comment style
+_CPP_EXTENSIONS = {".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"}
+
+
+def _comment_prefix_for_path(path: str) -> str:
+    """Return the comment prefix for the given file path.
+
+    C/C++ extensions get ``//``, everything else gets ``#``.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    return "//" if ext in _CPP_EXTENSIONS else "#"
+
+
+def _has_evolve_block_markers(content: str) -> bool:
+    """Check whether *content* already contains EVOLVE-BLOCK markers.
+
+    The check is comment-style-agnostic: it looks for the bare marker
+    string ``EVOLVE-BLOCK-START`` which appears in both ``# EVOLVE-BLOCK-START``
+    and ``// EVOLVE-BLOCK-START``.
+    """
+    return _EVOLVE_BLOCK_MARKER_START in content
+
+
+# ---------------------------------------------------------------------------
+# Environment variable expansion helper
+# ---------------------------------------------------------------------------
+
+
+def _expand_env_vars_in_value(value: str) -> str:
+    """Expand ``${VAR}`` patterns in *value* using ``os.environ``.
+
+    Uses the same ``re.sub`` pattern as ``config.py:_expand_env_vars``.
+    Unmatched variables are left as-is.
+    """
+
+    def _replacer(match: re.Match) -> str:  # type: ignore[type-arg]
+        return os.environ.get(match.group(1), match.group(0))
+
+    return re.sub(r"\$\{(\w+)\}", _replacer, value)
+
+
+# ---------------------------------------------------------------------------
+# Credentials-file resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_credentials_file(ae_config: dict) -> None:
+    """Set ``GOOGLE_APPLICATION_CREDENTIALS`` from config if provided.
+
+    When ``ae_config["credentials_file"]`` is present and non-empty:
+    1. Expand ``${VAR}`` patterns in the path.
+    2. Validate the expanded path exists on disk.
+    3. Set the environment variable so that ``google.auth.default()``
+       picks it up.
+
+    When the key is absent or empty, this is a no-op — existing ADC
+    behaviour is preserved.
+    """
+    cred_path = ae_config.get("credentials_file")
+    if not cred_path:
+        return
+
+    cred_path = _expand_env_vars_in_value(cred_path)
+
+    if not os.path.isfile(cred_path):
+        raise ValueError(f"credentials_file not found: {cred_path}")
+
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_path
+    logger.info("Using credentials file: %s", cred_path)
+
+
+# ---------------------------------------------------------------------------
+# GCP credential validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_gcp_credentials() -> None:
+    """Fail fast with actionable error if GCP credentials are missing.
+
+    Checks that ``google-auth`` is installed and that Application Default
+    Credentials (ADC) are configured.
+    """
+    try:
+        import google.auth  # noqa: F811
+        import google.auth.exceptions
+
+        google.auth.default()
+    except ImportError:
+        raise ImportError(
+            "The 'alphaevolve' backend requires the google-auth package.\n"
+            "Install with: pip install google-auth"
+        )
+    except google.auth.exceptions.DefaultCredentialsError:
+        raise ValueError(
+            "AlphaEvolve backend requires GCP Application Default Credentials.\n"
+            "Set up credentials with one of:\n"
+            "  1. gcloud auth application-default login\n"
+            "  2. Set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json\n"
+            "  3. Run on a GCP VM/Cloud Shell with default service account"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Initial program construction
+# ---------------------------------------------------------------------------
+
+
+def _build_initial_program(
+    program_path: str, file_suffix: str = ".py"
+) -> dict:
+    """Build an AlphaEvolve initial-program payload from a local file.
+
+    * Raises ``ValueError`` with a clear message when the file is
+      missing or empty.
+    * Auto-wraps content with EVOLVE-BLOCK markers when absent.
+    * Passes through existing markers as-is.
+
+    Returns the dict structure expected by
+    ``AlphaEvolveExperiment.create_initial_program``.
+    """
+    if not program_path:
+        raise ValueError(
+            "Initial program file is required for the AlphaEvolve backend "
+            "but was not provided."
+        )
+    if not os.path.exists(program_path):
+        raise ValueError(
+            f"Initial program file not found at path: {program_path}"
+        )
+
+    with open(program_path, "r") as fh:
+        content = fh.read()
+
+    if not content.strip():
+        raise ValueError(f"Initial program file is empty: {program_path}")
+
+    if not _has_evolve_block_markers(content):
+        prefix = _comment_prefix_for_path(program_path)
+        start = f"{prefix} {_EVOLVE_BLOCK_MARKER_START}"
+        end = f"{prefix} {_EVOLVE_BLOCK_MARKER_END}"
+        content = f"{start}\n{content}\n{end}"
+
+    return {
+        "content": {
+            "files": [
+                {
+                    "path": os.path.basename(program_path),
+                    "content": content,
+                }
+            ]
+        },
+        "evaluation": {
+            "scores": {
+                "scores": [{"metric": "combined_score", "score": 0.0}]
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _get_alphaevolve_config(config_obj: Config) -> dict:
+    """Merge AlphaEvolve defaults with environment variable overrides.
+
+    Load defaults from ``alphaevolve_default.yaml``, overlay environment
+    variables (``ALPHAEVOLVE_PROJECT_ID``, ``ALPHAEVOLVE_ENGINE_ID``, ...),
+    and optionally merge a ``config_obj.alphaevolve`` dict if present.
+
+    Raises ``ValueError`` when required fields (``project_id``,
+    ``engine_id``) are still missing after merging.
+    """
+    from skydiscover.extras.external.defaults import load_defaults
+
+    raw = load_defaults("alphaevolve_default.yaml")
+    ae: dict = raw.get("alphaevolve", {}) if raw else {}
+
+    _env_map = {
+        "ALPHAEVOLVE_PROJECT_ID": "project_id",
+        "ALPHAEVOLVE_ENGINE_ID": "engine_id",
+        "ALPHAEVOLVE_LOCATION": "location",
+        "ALPHAEVOLVE_COLLECTION": "collection",
+        "ALPHAEVOLVE_ASSISTANT": "assistant",
+        "ALPHAEVOLVE_NUM_EVALUATORS": "num_evaluators",
+        "ALPHAEVOLVE_NUM_SAMPLERS": "num_samplers",
+        "ALPHAEVOLVE_CREDENTIALS_FILE": "credentials_file",
+    }
+    _int_keys = {"num_evaluators", "num_samplers"}
+
+    for env_var, config_key in _env_map.items():
+        val = os.environ.get(env_var)
+        if val is not None:
+            ae[config_key] = int(val) if config_key in _int_keys else val
+
+    # Future-proofing: merge from Config object if present
+    obj_ae = getattr(config_obj, "alphaevolve", None)
+    if isinstance(obj_ae, dict):
+        ae.update(obj_ae)
+
+    logger.debug("AlphaEvolve config resolved: %s", ae)
+
+    # Validate required fields
+    if not ae.get("project_id") or not ae.get("engine_id"):
+        raise ValueError(
+            "AlphaEvolve backend requires 'project_id' and 'engine_id'.\n"
+            "Provide them via environment variables:\n"
+            "  export ALPHAEVOLVE_PROJECT_ID=your-gcp-project\n"
+            "  export ALPHAEVOLVE_ENGINE_ID=your-engine-id\n"
+            "Or via the alphaevolve: section in your config YAML."
+        )
+
+    return ae
+
+
+# ---------------------------------------------------------------------------
+# Score bridging
+# ---------------------------------------------------------------------------
+
+
+def _metrics_to_ae_scores(metrics: dict) -> dict:
+    """Convert a skydiscover metrics dict to AlphaEvolve score format.
+
+    Returns the **pre-wrapped** format so that
+    ``AlphaEvolveExperiment.evaluator()`` detects the ``scores`` key and
+    passes through without legacy wrapping.
+    """
+    scores_list = [
+        {"metric": k, "score": float(v)}
+        for k, v in metrics.items()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    ]
+    return {"scores": {"scores": scores_list}, "insights": {}}
+
+
+def _ae_scores_to_metrics(evaluation: dict) -> dict:
+    """Convert an AlphaEvolve evaluation dict to a skydiscover metrics dict.
+
+    If no ``combined_score`` key is present but other scores exist, the
+    first score value is used as ``combined_score``.
+    """
+    if not evaluation:
+        return {}
+    scores = (evaluation.get("scores") or {}).get("scores") or []
+    metrics: Dict[str, float] = {}
+    for s in scores:
+        metric = s.get("metric", "score")
+        score = s.get("score", 0.0)
+        metrics[metric] = float(score) if score is not None else 0.0
+
+    if "combined_score" not in metrics and metrics:
+        metrics["combined_score"] = list(metrics.values())[0]
+
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Evaluator adapter
+# ---------------------------------------------------------------------------
+
+
+def _make_alphaevolve_evaluator(
+    evaluator_path: str,
+    monitor_callback: Optional[Callable] = None,
+) -> Callable[[dict], dict]:
+    """Wrap a skydiscover file-based evaluator for the AlphaEvolve SDK.
+
+    The returned closure accepts an AlphaEvolve program dict
+    (``{content: {files: [...]}, ...}``) and returns an evaluation dict
+    in the pre-wrapped ``{scores: {scores: [...]}, insights: {}}`` format.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_skydiscover_eval", evaluator_path
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Could not load evaluator spec from {evaluator_path}")
+    eval_module = importlib.util.module_from_spec(spec)
+
+    eval_dir = os.path.dirname(os.path.abspath(evaluator_path))
+    if eval_dir not in sys.path:
+        sys.path.insert(0, eval_dir)
+
+    spec.loader.exec_module(eval_module)
+    user_evaluate = eval_module.evaluate
+
+    # Detect file suffix from the evaluator path directory or default
+    file_suffix = ".py"
+    eval_counter = [0]
+
+    def ae_evaluator(program: dict) -> dict:
+        files = program.get("content", {}).get("files", [])
+        if not files:
+            return {
+                "scores": {"scores": []},
+                "insights": {"error": "No files in candidate"},
+            }
+
+        if len(files) > 1:
+            logger.warning(
+                "AlphaEvolve returned %d files; only single-file is "
+                "supported, using files[0] only.",
+                len(files),
+            )
+
+        code = files[0].get("content", "")
+
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=file_suffix,
+            prefix="ae_candidate_",
+            delete=False,
+            encoding="utf-8",
+        )
+        try:
+            tmp.write(code)
+            tmp.flush()
+            tmp.close()
+
+            metrics = user_evaluate(tmp.name)
+
+            # Normalize metrics to dict
+            if metrics is None:
+                metrics = {}
+            elif isinstance(metrics, (int, float)):
+                metrics = {"combined_score": float(metrics)}
+            elif not isinstance(metrics, dict):
+                try:
+                    metrics = dict(metrics)
+                except (TypeError, ValueError):
+                    metrics = {}
+
+            eval_counter[0] += 1
+
+            # Push to monitor if callback provided
+            if monitor_callback:
+                try:
+                    prog = Program(
+                        id=str(uuid.uuid4()),
+                        solution=code,
+                        language="python",
+                        metrics=dict(metrics),
+                        iteration_found=eval_counter[0],
+                        generation=eval_counter[0],
+                    )
+                    monitor_callback(prog, eval_counter[0])
+                except Exception:
+                    logger.debug("Monitor callback error", exc_info=True)
+
+            # Bridge to AlphaEvolve score format (pre-wrapped)
+            return _metrics_to_ae_scores(metrics)
+
+        except Exception as e:
+            logger.warning("AlphaEvolve evaluator error: %s", e)
+            return {
+                "scores": {"scores": []},
+                "insights": {"error": str(e)},
+            }
+        finally:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+
+    return ae_evaluator
+
+
+# ---------------------------------------------------------------------------
+# Experiment config
+# ---------------------------------------------------------------------------
+
+
+def _build_experiment_config(
+    config_obj: Config, ae_config: dict, iterations: int
+) -> dict:
+    """Build an AlphaEvolve experiment config from skydiscover Config.
+
+    Auto-derives sensible defaults from skydiscover's config and allows
+    overrides from the ``alphaevolve:`` YAML section.
+    """
+    exp_config: Dict[str, Any] = {
+        "title": ae_config.get("title", "SkyDiscover Evolution"),
+        "problem_description": ae_config.get(
+            "problem_description",
+            getattr(config_obj, "system_prompt_override", None)
+            or "Evolve the program to maximize the evaluation score.",
+        ),
+        "run_settings": {
+            "max_programs": ae_config.get("max_programs", iterations),
+            "concurrency": ae_config.get(
+                "concurrency", ae_config.get("num_evaluators", 1)
+            ),
+        },
+    }
+
+    # Allow override of optional keys from ae_config
+    for key in ("program_language", "generation_settings"):
+        if key in ae_config:
+            exp_config[key] = ae_config[key]
+
+    return exp_config
+
+
+# ---------------------------------------------------------------------------
+# Best-program extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_best_program(
+    experiment: Any, metric_name: str = "combined_score"
+) -> Tuple[str, dict]:
+    """Extract the best program and its metrics from a completed experiment.
+
+    Queries the API for programs sorted by score descending and returns
+    the top result's code and metrics.
+    """
+    response = experiment.list_programs(
+        params={"order_by": "score desc"}
+    )
+    if not response or "alphaEvolvePrograms" not in response:
+        return ("", {})
+
+    programs = response["alphaEvolvePrograms"]
+    if not programs:
+        return ("", {})
+
+    best = programs[0]
+
+    files = best.get("content", {}).get("files", [])
+    code = files[0].get("content", "") if files else ""
+
+    # Extract metrics
+    metrics = _ae_scores_to_metrics(best.get("evaluation", {}))
+    return (code, metrics)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def run(
+    program_path: str,
+    evaluator_path: str,
+    config_obj: Config,
+    iterations: int,
+    output_dir: str,
+    monitor_callback: Optional[Callable] = None,
+    feedback_reader: Optional[Any] = None,
+) -> DiscoveryResult:
+    """Run evolution using AlphaEvolve's cloud API.
+
+    This is the external backend entry point called by ``api.py`` when
+    ``search_type == "alphaevolve"``.  It orchestrates the full experiment
+    lifecycle: GCP auth validation, initial program upload, experiment
+    creation, controller loop (sampling + evaluation workers), and
+    best-program extraction.
+
+    Calls the public AlphaEvolve SDK controller with
+    minimal wrapper code for config mapping and result extraction.
+    """
+    # Lazy imports of vendored SDK (per external backend pattern)
+    from alpha_evolve.client import AlphaEvolveClient
+    from alpha_evolve.controller import run_controller_loop
+    from alpha_evolve.experiment import AlphaEvolveExperiment
+
+    # 1. Read alphaevolve config section — resolved first so
+    #    credentials_file can set GOOGLE_APPLICATION_CREDENTIALS before
+    #    the ADC check.
+    ae_config = _get_alphaevolve_config(config_obj)
+    _resolve_credentials_file(ae_config)
+
+    # 2. Validate prerequisites
+    _validate_gcp_credentials()
+    file_suffix = getattr(config_obj, "file_suffix", ".py") or ".py"
+    initial_program = _build_initial_program(program_path, file_suffix)
+
+    # 3. Build client
+    client = AlphaEvolveClient(
+        project_id=ae_config["project_id"],
+        engine=ae_config["engine_id"],
+        location=ae_config.get("location", "global"),
+        collection=ae_config.get("collection", "default_collection"),
+        assistant=ae_config.get("assistant", "default_assistant"),
+    )
+
+    # 4. Build evaluator adapter
+    evaluator = _make_alphaevolve_evaluator(
+        evaluator_path, monitor_callback
+    )
+
+    # 5. Create experiment
+    num_evaluators = ae_config.get("num_evaluators", 1)
+    experiment = AlphaEvolveExperiment(
+        client,
+        evaluator,
+        max_programs_evaluated=iterations,
+        parallel_evaluation=(num_evaluators > 1),
+    )
+    exp_config = _build_experiment_config(config_obj, ae_config, iterations)
+    experiment.create_experiment(exp_config)
+    experiment.create_initial_program(initial_program)
+    experiment.start_experiment()
+
+    # 6. Run controller loop
+    # Directly await -- do NOT use asyncio.run()
+    await run_controller_loop(
+        experiment,
+        num_samplers=ae_config.get("num_samplers", 1),
+        num_evaluators=num_evaluators,
+        idle_timeout_s=ae_config.get("idle_timeout_s", 120),
+    )
+
+    # 7. Post-loop submission gap check
+    stats = experiment.stats
+    generated = stats.get("num_programs_generated", 0)
+    evaluated = stats.get("num_programs_evaluated", 0)
+    if generated > 0 and evaluated < generated:
+        failed = generated - evaluated
+        failure_rate = failed / generated
+        if failure_rate >= 0.25 and generated >= 4:
+            logger.warning(
+                "HIGH SUBMISSION FAILURE RATE: %d/%d programs were generated "
+                "but only %d were successfully evaluated (%.0f%% failure "
+                "rate). Common causes: evaluator too slow (lock-token "
+                "expiry), auth errors, or API rate limits.",
+                generated,
+                generated,
+                evaluated,
+                failure_rate * 100,
+            )
+
+    # 8. Extract best program
+    best_code, metrics = _extract_best_program(experiment)
+    best_score = metrics.get("combined_score", 0.0)
+
+    # 9. Build and return DiscoveryResult
+    best_program = Program(
+        id=str(uuid.uuid4()),
+        solution=best_code,
+        language=getattr(config_obj, "language", None) or "python",
+        metrics=metrics,
+        iteration_found=0,
+    )
+
+    return DiscoveryResult(
+        best_program=best_program,
+        best_score=best_score,
+        best_solution=best_code,
+        metrics=metrics,
+        output_dir=output_dir,
+    )

--- a/skydiscover/extras/external/alphaevolve_backend.py
+++ b/skydiscover/extras/external/alphaevolve_backend.py
@@ -141,9 +141,7 @@ def _validate_gcp_credentials() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_initial_program(
-    program_path: str, file_suffix: str = ".py"
-) -> dict:
+def _build_initial_program(program_path: str) -> dict:
     """Build an AlphaEvolve initial-program payload from a local file.
 
     * Raises ``ValueError`` with a clear message when the file is
@@ -156,13 +154,10 @@ def _build_initial_program(
     """
     if not program_path:
         raise ValueError(
-            "Initial program file is required for the AlphaEvolve backend "
-            "but was not provided."
+            "Initial program file is required for the AlphaEvolve backend but was not provided."
         )
     if not os.path.exists(program_path):
-        raise ValueError(
-            f"Initial program file not found at path: {program_path}"
-        )
+        raise ValueError(f"Initial program file not found at path: {program_path}")
 
     with open(program_path, "r") as fh:
         content = fh.read()
@@ -185,11 +180,7 @@ def _build_initial_program(
                 }
             ]
         },
-        "evaluation": {
-            "scores": {
-                "scores": [{"metric": "combined_score", "score": 0.0}]
-            }
-        },
+        "evaluation": {"scores": {"scores": [{"metric": "combined_score", "score": 0.0}]}},
     }
 
 
@@ -199,11 +190,11 @@ def _build_initial_program(
 
 
 def _get_alphaevolve_config(config_obj: Config) -> dict:
-    """Merge AlphaEvolve defaults with environment variable overrides.
+    """Resolve the AlphaEvolve config section.
 
-    Load defaults from ``alphaevolve_default.yaml``, overlay environment
-    variables (``ALPHAEVOLVE_PROJECT_ID``, ``ALPHAEVOLVE_ENGINE_ID``, ...),
-    and optionally merge a ``config_obj.alphaevolve`` dict if present.
+    Precedence (lowest to highest): ``alphaevolve_default.yaml`` <
+    the ``alphaevolve:`` section of the user config < environment
+    variables (``ALPHAEVOLVE_PROJECT_ID``, ``ALPHAEVOLVE_ENGINE_ID``, ...).
 
     Raises ``ValueError`` when required fields (``project_id``,
     ``engine_id``) are still missing after merging.
@@ -212,6 +203,11 @@ def _get_alphaevolve_config(config_obj: Config) -> dict:
 
     raw = load_defaults("alphaevolve_default.yaml")
     ae: dict = raw.get("alphaevolve", {}) if raw else {}
+
+    # User config (-c config.yaml) overrides the shipped defaults.
+    obj_ae = getattr(config_obj, "alphaevolve", None)
+    if isinstance(obj_ae, dict):
+        ae.update(obj_ae)
 
     _env_map = {
         "ALPHAEVOLVE_PROJECT_ID": "project_id",
@@ -229,11 +225,6 @@ def _get_alphaevolve_config(config_obj: Config) -> dict:
         val = os.environ.get(env_var)
         if val is not None:
             ae[config_key] = int(val) if config_key in _int_keys else val
-
-    # Future-proofing: merge from Config object if present
-    obj_ae = getattr(config_obj, "alphaevolve", None)
-    if isinstance(obj_ae, dict):
-        ae.update(obj_ae)
 
     logger.debug("AlphaEvolve config resolved: %s", ae)
 
@@ -299,16 +290,20 @@ def _ae_scores_to_metrics(evaluation: dict) -> dict:
 def _make_alphaevolve_evaluator(
     evaluator_path: str,
     monitor_callback: Optional[Callable] = None,
+    file_suffix: str = ".py",
+    language: str = "python",
 ) -> Callable[[dict], dict]:
     """Wrap a skydiscover file-based evaluator for the AlphaEvolve SDK.
 
     The returned closure accepts an AlphaEvolve program dict
     (``{content: {files: [...]}, ...}``) and returns an evaluation dict
     in the pre-wrapped ``{scores: {scores: [...]}, insights: {}}`` format.
+
+    ``file_suffix`` is the extension used for the temporary candidate file
+    handed to the user's ``evaluate(path)``. It matters for non-Python runs,
+    where evaluators dispatch on the extension.
     """
-    spec = importlib.util.spec_from_file_location(
-        "_skydiscover_eval", evaluator_path
-    )
+    spec = importlib.util.spec_from_file_location("_skydiscover_eval", evaluator_path)
     if spec is None or spec.loader is None:
         raise ValueError(f"Could not load evaluator spec from {evaluator_path}")
     eval_module = importlib.util.module_from_spec(spec)
@@ -320,8 +315,6 @@ def _make_alphaevolve_evaluator(
     spec.loader.exec_module(eval_module)
     user_evaluate = eval_module.evaluate
 
-    # Detect file suffix from the evaluator path directory or default
-    file_suffix = ".py"
     eval_counter = [0]
 
     def ae_evaluator(program: dict) -> dict:
@@ -341,19 +334,23 @@ def _make_alphaevolve_evaluator(
 
         code = files[0].get("content", "")
 
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=file_suffix,
-            prefix="ae_candidate_",
-            delete=False,
-            encoding="utf-8",
-        )
-        try:
-            tmp.write(code)
-            tmp.flush()
-            tmp.close()
+        # Prefer the extension AlphaEvolve used for the candidate file, so a
+        # C++/CUDA candidate reaches the evaluator as e.g. ".cu" and not ".py".
+        suffix = os.path.splitext(files[0].get("path", ""))[1] or file_suffix
 
-            metrics = user_evaluate(tmp.name)
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=suffix,
+                prefix="ae_candidate_",
+                delete=False,
+                encoding="utf-8",
+            ) as tmp:
+                tmp_path = tmp.name
+                tmp.write(code)
+
+            metrics = user_evaluate(tmp_path)
 
             # Normalize metrics to dict
             if metrics is None:
@@ -374,7 +371,7 @@ def _make_alphaevolve_evaluator(
                     prog = Program(
                         id=str(uuid.uuid4()),
                         solution=code,
-                        language="python",
+                        language=language,
                         metrics=dict(metrics),
                         iteration_found=eval_counter[0],
                         generation=eval_counter[0],
@@ -393,10 +390,11 @@ def _make_alphaevolve_evaluator(
                 "insights": {"error": str(e)},
             }
         finally:
-            try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     return ae_evaluator
 
@@ -406,9 +404,7 @@ def _make_alphaevolve_evaluator(
 # ---------------------------------------------------------------------------
 
 
-def _build_experiment_config(
-    config_obj: Config, ae_config: dict, iterations: int
-) -> dict:
+def _build_experiment_config(config_obj: Config, ae_config: dict, iterations: int) -> dict:
     """Build an AlphaEvolve experiment config from skydiscover Config.
 
     Auto-derives sensible defaults from skydiscover's config and allows
@@ -423,11 +419,15 @@ def _build_experiment_config(
         ),
         "run_settings": {
             "max_programs": ae_config.get("max_programs", iterations),
-            "concurrency": ae_config.get(
-                "concurrency", ae_config.get("num_evaluators", 1)
-            ),
+            "concurrency": ae_config.get("concurrency", ae_config.get("num_evaluators", 1)),
         },
     }
+
+    # Tell AlphaEvolve which language it is evolving (defaults to skydiscover's
+    # `language:` setting) so generated candidates are in the right language.
+    language = getattr(config_obj, "language", None)
+    if language:
+        exp_config["program_language"] = language
 
     # Allow override of optional keys from ae_config
     for key in ("program_language", "generation_settings"):
@@ -442,17 +442,15 @@ def _build_experiment_config(
 # ---------------------------------------------------------------------------
 
 
-def _extract_best_program(
-    experiment: Any, metric_name: str = "combined_score"
-) -> Tuple[str, dict]:
+def _extract_best_program(experiment: Any, metric_name: str = "combined_score") -> Tuple[str, dict]:
     """Extract the best program and its metrics from a completed experiment.
 
-    Queries the API for programs sorted by score descending and returns
-    the top result's code and metrics.
+    Asks the API for programs sorted by score descending, then picks the
+    best one on *metric_name* locally. The AlphaEvolve examples do the same,
+    because the server-side ordering is not guaranteed to match the metric
+    this run optimises.
     """
-    response = experiment.list_programs(
-        params={"order_by": "score desc"}
-    )
+    response = experiment.list_programs(params={"order_by": "score desc"})
     if not response or "alphaEvolvePrograms" not in response:
         return ("", {})
 
@@ -460,13 +458,12 @@ def _extract_best_program(
     if not programs:
         return ("", {})
 
-    best = programs[0]
+    scored = [(_ae_scores_to_metrics(p.get("evaluation", {})), p) for p in programs]
+    metrics, best = max(scored, key=lambda pair: pair[0].get(metric_name, float("-inf")))
 
     files = best.get("content", {}).get("files", [])
     code = files[0].get("content", "") if files else ""
 
-    # Extract metrics
-    metrics = _ae_scores_to_metrics(best.get("evaluation", {}))
     return (code, metrics)
 
 
@@ -509,7 +506,8 @@ async def run(
     # 2. Validate prerequisites
     _validate_gcp_credentials()
     file_suffix = getattr(config_obj, "file_suffix", ".py") or ".py"
-    initial_program = _build_initial_program(program_path, file_suffix)
+    language = getattr(config_obj, "language", None) or "python"
+    initial_program = _build_initial_program(program_path)
 
     # 3. Build client
     client = AlphaEvolveClient(
@@ -521,9 +519,7 @@ async def run(
     )
 
     # 4. Build evaluator adapter
-    evaluator = _make_alphaevolve_evaluator(
-        evaluator_path, monitor_callback
-    )
+    evaluator = _make_alphaevolve_evaluator(evaluator_path, monitor_callback, file_suffix, language)
 
     # 5. Create experiment
     num_evaluators = ae_config.get("num_evaluators", 1)
@@ -556,13 +552,12 @@ async def run(
         failure_rate = failed / generated
         if failure_rate >= 0.25 and generated >= 4:
             logger.warning(
-                "HIGH SUBMISSION FAILURE RATE: %d/%d programs were generated "
-                "but only %d were successfully evaluated (%.0f%% failure "
-                "rate). Common causes: evaluator too slow (lock-token "
-                "expiry), auth errors, or API rate limits.",
+                "HIGH SUBMISSION FAILURE RATE: %d of %d generated programs "
+                "(%.0f%%) were never evaluated successfully. Common causes: "
+                "evaluator too slow (lock-token expiry), auth errors, or API "
+                "rate limits.",
+                failed,
                 generated,
-                generated,
-                evaluated,
                 failure_rate * 100,
             )
 
@@ -574,7 +569,7 @@ async def run(
     best_program = Program(
         id=str(uuid.uuid4()),
         solution=best_code,
-        language=getattr(config_obj, "language", None) or "python",
+        language=language,
         metrics=metrics,
         iteration_found=0,
     )

--- a/skydiscover/extras/external/defaults/alphaevolve_default.yaml
+++ b/skydiscover/extras/external/defaults/alphaevolve_default.yaml
@@ -1,9 +1,10 @@
 # Tuned defaults for the AlphaEvolve backend.
 # Applied when no user config (-c) overrides these values.
 #
-# Required fields (project_id, engine_id) must be provided by the user
-# via their own config file or environment. They are commented out here
-# to avoid committing real GCP credentials.
+# Required fields (project_id, engine_id) must be provided by the user via an
+# `alphaevolve:` section in their own config file (-c) or via the
+# ALPHAEVOLVE_* environment variables, which take precedence. They are
+# commented out here to avoid committing real GCP credentials.
 
 alphaevolve:
   # ---- Required GCP settings ------------------------------------------------
@@ -31,8 +32,13 @@ alphaevolve:
   # Number of concurrent sampling workers that poll for new candidates.
   num_samplers: 1
 
-  # Number of concurrent evaluation workers. Set higher for fast evaluators.
-  # When > 1, evaluators run in parallel threads.
+  # Number of concurrent evaluation workers.
+  # 1 (the default) runs the evaluator inline on the event loop, which blocks
+  # sampling while an evaluation is in flight. That is fine for fast
+  # evaluators, and required by evaluators that use signal.alarm (main thread
+  # only). Use more than 1 for slow evaluators such as compile/benchmark
+  # loops, where inline evaluation can starve the samplers and let candidate
+  # lock tokens expire.
   num_evaluators: 1
 
   # ---- Experiment settings ---------------------------------------------------

--- a/skydiscover/extras/external/defaults/alphaevolve_default.yaml
+++ b/skydiscover/extras/external/defaults/alphaevolve_default.yaml
@@ -1,0 +1,48 @@
+# Tuned defaults for the AlphaEvolve backend.
+# Applied when no user config (-c) overrides these values.
+#
+# Required fields (project_id, engine_id) must be provided by the user
+# via their own config file or environment. They are commented out here
+# to avoid committing real GCP credentials.
+
+alphaevolve:
+  # ---- Required GCP settings ------------------------------------------------
+  # Your GCP project ID. Must have the Discovery Engine API enabled.
+  # project_id: "your-gcp-project-id"
+
+  # The Discovery Engine engine ID for your AlphaEvolve instance.
+  # engine_id: "your-engine-id"
+
+  # ---- Optional GCP settings ------------------------------------------------
+  # GCP location for the Discovery Engine resources.
+  location: "global"
+
+  # Discovery Engine collection ID.
+  collection: "default_collection"
+
+  # Discovery Engine assistant ID.
+  assistant: "default_assistant"
+
+  # Path to a GCP service-account JSON file. Overrides ambient ADC.
+  # Supports ${VAR} env-var expansion (e.g., ${HOME}/.config/sa.json).
+  # credentials_file: "/path/to/service-account.json"
+
+  # ---- Worker settings -------------------------------------------------------
+  # Number of concurrent sampling workers that poll for new candidates.
+  num_samplers: 1
+
+  # Number of concurrent evaluation workers. Set higher for fast evaluators.
+  # When > 1, evaluators run in parallel threads.
+  num_evaluators: 1
+
+  # ---- Experiment settings ---------------------------------------------------
+  # Experiment title. Auto-derived from skydiscover config if not set.
+  # title: "My AlphaEvolve Experiment"
+
+  # Problem description for the experiment. Auto-derived from system_prompt if not set.
+  # problem_description: "Evolve the program to maximize score."
+
+  # ---- Timeout settings ------------------------------------------------------
+  # Seconds of inactivity (no new candidates, empty queue) before the controller
+  # loop exits early. Set to 0 to disable.
+  idle_timeout_s: 120

--- a/tests/extras/external/test_alphaevolve_config.py
+++ b/tests/extras/external/test_alphaevolve_config.py
@@ -1,0 +1,211 @@
+"""Unit tests for AlphaEvolve config resolution."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skydiscover.extras.external.alphaevolve_backend import (
+    _expand_env_vars_in_value,
+    _get_alphaevolve_config,
+    _resolve_credentials_file,
+)
+
+# Patch target for load_defaults (lazy import inside _get_alphaevolve_config)
+_LOAD_DEFAULTS = "skydiscover.extras.external.defaults.load_defaults"
+
+
+class TestGetAlphaevolveConfig:
+    """Tests for _get_alphaevolve_config."""
+
+    @patch(_LOAD_DEFAULTS, return_value={"alphaevolve": {"location": "global"}})
+    @patch.dict(
+        os.environ,
+        {
+            "ALPHAEVOLVE_PROJECT_ID": "env-project",
+            "ALPHAEVOLVE_ENGINE_ID": "env-engine",
+        },
+        clear=False,
+    )
+    def test_env_var_overrides(self, mock_defaults: MagicMock) -> None:
+        config_obj = MagicMock(spec=[])
+
+        result = _get_alphaevolve_config(config_obj)
+
+        assert result["project_id"] == "env-project"
+        assert result["engine_id"] == "env-engine"
+
+    @patch(_LOAD_DEFAULTS, return_value={"alphaevolve": {}})
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_required_fields_raises(
+        self, mock_defaults: MagicMock
+    ) -> None:
+        config_obj = MagicMock(spec=[])
+
+        with pytest.raises(ValueError, match="project_id"):
+            _get_alphaevolve_config(config_obj)
+
+    @patch(
+        _LOAD_DEFAULTS,
+        return_value={
+            "alphaevolve": {
+                "project_id": "p",
+                "engine_id": "e",
+                "location": "us-central1",
+            }
+        },
+    )
+    @patch.dict(os.environ, {}, clear=True)
+    def test_defaults_fallback(self, mock_defaults: MagicMock) -> None:
+        config_obj = MagicMock(spec=[])
+
+        result = _get_alphaevolve_config(config_obj)
+
+        assert result["location"] == "us-central1"
+        assert result["project_id"] == "p"
+
+    @patch(
+        _LOAD_DEFAULTS,
+        return_value={
+            "alphaevolve": {"project_id": "default-p", "engine_id": "default-e"}
+        },
+    )
+    @patch.dict(os.environ, {}, clear=True)
+    def test_config_obj_merge(self, mock_defaults: MagicMock) -> None:
+        config_obj = MagicMock()
+        config_obj.alphaevolve = {
+            "project_id": "from-obj",
+            "engine_id": "from-obj",
+        }
+
+        result = _get_alphaevolve_config(config_obj)
+
+        assert result["project_id"] == "from-obj"
+        assert result["engine_id"] == "from-obj"
+
+    @patch(
+        _LOAD_DEFAULTS,
+        return_value={
+            "alphaevolve": {"project_id": "p", "engine_id": "e"}
+        },
+    )
+    @patch.dict(
+        os.environ,
+        {
+            "ALPHAEVOLVE_NUM_EVALUATORS": "4",
+            "ALPHAEVOLVE_NUM_SAMPLERS": "2",
+        },
+        clear=False,
+    )
+    def test_int_keys_converted(self, mock_defaults: MagicMock) -> None:
+        config_obj = MagicMock(spec=[])
+
+        result = _get_alphaevolve_config(config_obj)
+
+        assert result["num_evaluators"] == 4
+        assert isinstance(result["num_evaluators"], int)
+        assert result["num_samplers"] == 2
+        assert isinstance(result["num_samplers"], int)
+
+
+class TestExpandEnvVarsInValue:
+    """Tests for _expand_env_vars_in_value standalone helper."""
+
+    def test_single_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_DIR", "/opt/creds")
+        assert _expand_env_vars_in_value("${MY_DIR}/sa.json") == "/opt/creds/sa.json"
+
+    def test_multiple_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BASE", "/home")
+        monkeypatch.setenv("USER", "alice")
+        assert _expand_env_vars_in_value("${BASE}/${USER}/key.json") == "/home/alice/key.json"
+
+    def test_unmatched_var_left_as_is(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NONEXISTENT_VAR_XYZ", raising=False)
+        assert _expand_env_vars_in_value("${NONEXISTENT_VAR_XYZ}/f.json") == "${NONEXISTENT_VAR_XYZ}/f.json"
+
+    def test_no_vars_passthrough(self) -> None:
+        assert _expand_env_vars_in_value("/plain/path.json") == "/plain/path.json"
+
+    def test_empty_string(self) -> None:
+        assert _expand_env_vars_in_value("") == ""
+
+
+class TestCredentialsFile:
+    """Tests for _resolve_credentials_file and credentials_file config."""
+
+    def test_credentials_file_sets_env_var(
+        self, tmp_path: "os.PathLike[str]", monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        sa_file = tmp_path / "sa.json"
+        sa_file.write_text("{}")
+        ae_config = {"credentials_file": str(sa_file)}
+
+        _resolve_credentials_file(ae_config)
+
+        assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(sa_file)
+
+    def test_credentials_file_expands_env_vars(
+        self, tmp_path: "os.PathLike[str]", monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.setenv("TEST_CRED_DIR", str(tmp_path))
+        sa_file = tmp_path / "sa.json"
+        sa_file.write_text("{}")
+        ae_config = {"credentials_file": "${TEST_CRED_DIR}/sa.json"}
+
+        _resolve_credentials_file(ae_config)
+
+        assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(sa_file)
+
+    def test_credentials_file_missing_raises(self) -> None:
+        ae_config = {"credentials_file": "/nonexistent/path.json"}
+
+        with pytest.raises(ValueError, match="credentials_file not found"):
+            _resolve_credentials_file(ae_config)
+
+    def test_credentials_file_unset_no_clobber(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", "/original/path.json"
+        )
+        ae_config: dict = {}
+
+        _resolve_credentials_file(ae_config)
+
+        assert (
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+            == "/original/path.json"
+        )
+
+    def test_credentials_file_empty_string_no_clobber(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        ae_config = {"credentials_file": ""}
+
+        _resolve_credentials_file(ae_config)
+
+        assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
+
+    @patch(
+        _LOAD_DEFAULTS,
+        return_value={
+            "alphaevolve": {"project_id": "p", "engine_id": "e"}
+        },
+    )
+    @patch.dict(
+        os.environ,
+        {"ALPHAEVOLVE_CREDENTIALS_FILE": "/some/path.json"},
+        clear=False,
+    )
+    def test_env_var_override_credentials_file(
+        self, mock_defaults: MagicMock
+    ) -> None:
+        config_obj = MagicMock(spec=[])
+
+        result = _get_alphaevolve_config(config_obj)
+
+        assert result["credentials_file"] == "/some/path.json"

--- a/tests/extras/external/test_alphaevolve_config.py
+++ b/tests/extras/external/test_alphaevolve_config.py
@@ -86,6 +86,51 @@ class TestGetAlphaevolveConfig:
     @patch(
         _LOAD_DEFAULTS,
         return_value={
+            "alphaevolve": {"project_id": "default-p", "engine_id": "default-e"}
+        },
+    )
+    @patch.dict(
+        os.environ,
+        {"ALPHAEVOLVE_PROJECT_ID": "from-env"},
+        clear=True,
+    )
+    def test_env_beats_config_section(self, mock_defaults: MagicMock) -> None:
+        config_obj = MagicMock()
+        config_obj.alphaevolve = {
+            "project_id": "from-obj",
+            "engine_id": "from-obj",
+        }
+
+        result = _get_alphaevolve_config(config_obj)
+
+        # Env is the ad-hoc override, the config file supplies the rest.
+        assert result["project_id"] == "from-env"
+        assert result["engine_id"] == "from-obj"
+
+    @patch(
+        _LOAD_DEFAULTS,
+        return_value={"alphaevolve": {"location": "global"}},
+    )
+    @patch.dict(os.environ, {}, clear=True)
+    def test_section_from_yaml_config_is_used(
+        self, mock_defaults: MagicMock
+    ) -> None:
+        """A user's `alphaevolve:` YAML section must survive Config parsing."""
+        from skydiscover.config import Config
+
+        config_obj = Config.from_dict(
+            {"alphaevolve": {"project_id": "yaml-p", "engine_id": "yaml-e"}}
+        )
+
+        result = _get_alphaevolve_config(config_obj)
+
+        assert result["project_id"] == "yaml-p"
+        assert result["engine_id"] == "yaml-e"
+        assert result["location"] == "global"
+
+    @patch(
+        _LOAD_DEFAULTS,
+        return_value={
             "alphaevolve": {"project_id": "p", "engine_id": "e"}
         },
     )

--- a/tests/extras/external/test_evaluator_adapter.py
+++ b/tests/extras/external/test_evaluator_adapter.py
@@ -1,0 +1,210 @@
+"""Unit tests for the AlphaEvolve evaluator adapter and result extraction."""
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from skydiscover.extras.external.alphaevolve_backend import (
+    _extract_best_program,
+    _make_alphaevolve_evaluator,
+)
+
+# Evaluator that records the path it was handed, so tests can assert on the
+# temp-file extension the adapter chose.
+_PATH_ECHO_EVALUATOR = """
+import os
+
+_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "seen.txt")
+
+
+def evaluate(program_path):
+    with open(_LOG, "a") as fh:
+        fh.write(program_path + "\\n")
+    with open(program_path) as src:
+        return {"combined_score": float(len(src.read()))}
+"""
+
+_FAILING_EVALUATOR = """
+def evaluate(program_path):
+    raise RuntimeError("boom")
+"""
+
+
+def _write_evaluator(tmp_path: Path, source: str) -> str:
+    path = tmp_path / "evaluator.py"
+    path.write_text(source)
+    return str(path)
+
+
+def _seen_paths(tmp_path: Path) -> List[str]:
+    log = tmp_path / "seen.txt"
+    return log.read_text().split() if log.exists() else []
+
+
+def _candidate(path: str, content: str = "x = 1") -> Dict[str, Any]:
+    return {"content": {"files": [{"path": path, "content": content}]}}
+
+
+@pytest.fixture
+def isolated_tmpdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point tempfile at a private dir so leftovers are attributable."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(scratch))
+    return scratch
+
+
+class TestEvaluatorSuffix:
+    """The candidate temp file must carry the run's language extension."""
+
+    def test_uses_candidate_file_extension(self, tmp_path: Path) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR),
+            file_suffix=".py",
+        )
+
+        evaluator(_candidate("kernel.cu", "__global__ void k() {}"))
+
+        assert _seen_paths(tmp_path)[0].endswith(".cu")
+
+    def test_falls_back_to_configured_suffix(self, tmp_path: Path) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR),
+            file_suffix=".cpp",
+        )
+
+        # No path on the candidate -> the configured file_suffix wins.
+        evaluator(_candidate("", "int main() { return 0; }"))
+
+        assert _seen_paths(tmp_path)[0].endswith(".cpp")
+
+    def test_python_default(self, tmp_path: Path) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR)
+        )
+
+        evaluator(_candidate("seed.py"))
+
+        assert _seen_paths(tmp_path)[0].endswith(".py")
+
+
+class TestEvaluatorAdapter:
+    """Behaviour of the wrapped evaluator closure."""
+
+    def test_scores_are_pre_wrapped(self, tmp_path: Path) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR)
+        )
+
+        result = evaluator(_candidate("seed.py", "abc"))
+
+        assert result["scores"]["scores"] == [
+            {"metric": "combined_score", "score": 3.0}
+        ]
+
+    def test_monitor_callback_gets_run_language(self, tmp_path: Path) -> None:
+        seen: List[Any] = []
+
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR),
+            monitor_callback=lambda prog, it: seen.append(prog),
+            file_suffix=".cu",
+            language="cuda",
+        )
+
+        evaluator(_candidate("kernel.cu", "__global__ void k() {}"))
+
+        assert len(seen) == 1
+        assert seen[0].language == "cuda"
+
+    def test_evaluator_error_returns_insight(self, tmp_path: Path) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _FAILING_EVALUATOR)
+        )
+
+        result = evaluator(_candidate("seed.py"))
+
+        assert result["scores"]["scores"] == []
+        assert "boom" in result["insights"]["error"]
+
+    def test_no_files_returns_insight(self, tmp_path: Path) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR)
+        )
+
+        result = evaluator({"content": {"files": []}})
+
+        assert result["scores"]["scores"] == []
+        assert "error" in result["insights"]
+
+    def test_temp_file_is_cleaned_up(
+        self, tmp_path: Path, isolated_tmpdir: Path
+    ) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _PATH_ECHO_EVALUATOR)
+        )
+
+        evaluator(_candidate("seed.py"))
+
+        assert os.listdir(isolated_tmpdir) == []
+
+    def test_temp_file_is_cleaned_up_on_evaluator_error(
+        self, tmp_path: Path, isolated_tmpdir: Path
+    ) -> None:
+        evaluator = _make_alphaevolve_evaluator(
+            _write_evaluator(tmp_path, _FAILING_EVALUATOR)
+        )
+
+        evaluator(_candidate("seed.py"))
+
+        assert os.listdir(isolated_tmpdir) == []
+
+
+class _FakeExperiment:
+    def __init__(self, programs: List[Dict[str, Any]]) -> None:
+        self._programs = programs
+
+    def list_programs(self, params: Any = None) -> Dict[str, Any]:
+        return {"alphaEvolvePrograms": self._programs}
+
+
+def _program(code: str, score: float) -> Dict[str, Any]:
+    return {
+        "content": {"files": [{"path": "p.py", "content": code}]},
+        "evaluation": {
+            "scores": {"scores": [{"metric": "combined_score", "score": score}]}
+        },
+    }
+
+
+class TestExtractBestProgram:
+    """The API's ordering is not trusted, the best score must win."""
+
+    def test_picks_highest_score_when_unordered(self) -> None:
+        experiment = _FakeExperiment(
+            [_program("low", 0.1), _program("high", 0.9), _program("mid", 0.5)]
+        )
+
+        code, metrics = _extract_best_program(experiment)
+
+        assert code == "high"
+        assert metrics["combined_score"] == 0.9
+
+    def test_empty_response(self) -> None:
+        assert _extract_best_program(_FakeExperiment([])) == ("", {})
+
+    def test_program_without_scores_is_not_preferred(self) -> None:
+        experiment = _FakeExperiment(
+            [
+                {"content": {"files": [{"content": "unscored"}]}},
+                _program("ok", 0.2),
+            ]
+        )
+
+        code, metrics = _extract_best_program(experiment)
+
+        assert code == "ok"
+        assert metrics["combined_score"] == 0.2

--- a/tests/extras/external/test_initial_program.py
+++ b/tests/extras/external/test_initial_program.py
@@ -1,0 +1,178 @@
+"""Unit tests for AlphaEvolve initial program construction."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from skydiscover.extras.external.alphaevolve_backend import (
+    _EVOLVE_BLOCK_END,
+    _EVOLVE_BLOCK_MARKER_END,
+    _EVOLVE_BLOCK_MARKER_START,
+    _EVOLVE_BLOCK_START,
+    _build_initial_program,
+    _comment_prefix_for_path,
+    _has_evolve_block_markers,
+)
+
+
+class TestBuildInitialProgram:
+    """Tests for _build_initial_program."""
+
+    def test_auto_wraps_evolve_block(self, tmp_path: Path) -> None:
+        seed = tmp_path / "seed.py"
+        seed.write_text("def solve(): return 42")
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.startswith(_EVOLVE_BLOCK_START)
+        assert content.endswith(_EVOLVE_BLOCK_END)
+
+    def test_passes_through_existing_markers(self, tmp_path: Path) -> None:
+        code = f"{_EVOLVE_BLOCK_START}\ndef solve(): return 42\n{_EVOLVE_BLOCK_END}"
+        seed = tmp_path / "seed.py"
+        seed.write_text(code)
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.count(_EVOLVE_BLOCK_START) == 1
+
+    def test_missing_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            _build_initial_program("/nonexistent/path.py")
+
+    def test_empty_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="required"):
+            _build_initial_program("")
+
+    def test_empty_file_raises(self, tmp_path: Path) -> None:
+        seed = tmp_path / "empty.py"
+        seed.write_text("   ")
+
+        with pytest.raises(ValueError, match="empty"):
+            _build_initial_program(str(seed))
+
+    def test_payload_structure(self, tmp_path: Path) -> None:
+        seed = tmp_path / "prog.py"
+        seed.write_text("x = 1")
+
+        result = _build_initial_program(str(seed))
+
+        assert "content" in result
+        assert "files" in result["content"]
+        files = result["content"]["files"]
+        assert len(files) == 1
+        assert files[0]["path"] == "prog.py"
+        assert "evaluation" in result
+
+
+class TestCommentPrefixForPath:
+    """Tests for _comment_prefix_for_path helper."""
+
+    @pytest.mark.parametrize(
+        "ext",
+        [".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"],
+    )
+    def test_cpp_extensions(self, ext: str) -> None:
+        assert _comment_prefix_for_path(f"foo{ext}") == "//"
+
+    @pytest.mark.parametrize(
+        "ext",
+        [".py", ".yaml", ".txt", ".rs"],
+    )
+    def test_python_and_default(self, ext: str) -> None:
+        assert _comment_prefix_for_path(f"foo{ext}") == "#"
+
+
+class TestHasEvolveBlockMarkers:
+    """Tests for _has_evolve_block_markers helper."""
+
+    def test_detects_python_style(self) -> None:
+        content = "# EVOLVE-BLOCK-START\ncode\n# EVOLVE-BLOCK-END"
+        assert _has_evolve_block_markers(content) is True
+
+    def test_detects_cpp_style(self) -> None:
+        content = "// EVOLVE-BLOCK-START\ncode\n// EVOLVE-BLOCK-END"
+        assert _has_evolve_block_markers(content) is True
+
+    def test_no_markers(self) -> None:
+        assert _has_evolve_block_markers("just code") is False
+
+
+class TestBuildInitialProgramLanguageAware:
+    """Tests for language-aware _build_initial_program behaviour."""
+
+    def test_cpp_auto_wraps_with_cpp_markers(self, tmp_path: Path) -> None:
+        seed = tmp_path / "prefetcher.cpp"
+        seed.write_text("int main() { return 0; }")
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.startswith("// EVOLVE-BLOCK-START")
+        assert content.endswith("// EVOLVE-BLOCK-END")
+
+    def test_cpp_passes_through_existing_cpp_markers(
+        self, tmp_path: Path
+    ) -> None:
+        code = "// EVOLVE-BLOCK-START\nint main() { return 0; }\n// EVOLVE-BLOCK-END"
+        seed = tmp_path / "prefetcher.cpp"
+        seed.write_text(code)
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.count("EVOLVE-BLOCK-START") == 1
+
+    def test_py_auto_wraps_with_python_markers(self, tmp_path: Path) -> None:
+        seed = tmp_path / "solver.py"
+        seed.write_text("def solve(): return 42")
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.startswith("# EVOLVE-BLOCK-START")
+        assert content.endswith("# EVOLVE-BLOCK-END")
+
+    def test_py_passes_through_existing_python_markers(
+        self, tmp_path: Path
+    ) -> None:
+        code = "# EVOLVE-BLOCK-START\ndef solve(): return 42\n# EVOLVE-BLOCK-END"
+        seed = tmp_path / "solver.py"
+        seed.write_text(code)
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.count("EVOLVE-BLOCK-START") == 1
+
+    def test_header_file_uses_cpp_markers(self, tmp_path: Path) -> None:
+        """A .h header file should get // style markers."""
+        seed = tmp_path / "prefetcher.h"
+        seed.write_text("#pragma once\nvoid prefetch();")
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.startswith("// EVOLVE-BLOCK-START")
+        assert content.endswith("// EVOLVE-BLOCK-END")
+
+    def test_cpp_no_double_wrap_python_markers(
+        self, tmp_path: Path
+    ) -> None:
+        """A .cpp file that already has # EVOLVE-BLOCK-START should pass through.
+
+        The bare marker string is detected regardless of comment prefix,
+        preventing double-wrapping even when the prefix doesn't match the
+        file extension.
+        """
+        code = "# EVOLVE-BLOCK-START\nint main() { return 0; }\n# EVOLVE-BLOCK-END"
+        seed = tmp_path / "prefetcher.cpp"
+        seed.write_text(code)
+
+        result = _build_initial_program(str(seed))
+
+        content = result["content"]["files"][0]["content"]
+        assert content.count("EVOLVE-BLOCK-START") == 1

--- a/tests/extras/external/test_integration.py
+++ b/tests/extras/external/test_integration.py
@@ -1,0 +1,171 @@
+"""
+Live integration test for the AlphaEvolve external backend.
+
+This test runs the full AlphaEvolve backend lifecycle against the real
+Google Discovery Engine API.  It is gated on GCP credentials **and** the
+required environment variables (``ALPHAEVOLVE_PROJECT_ID``,
+``ALPHAEVOLVE_ENGINE_ID``).  When either is missing the test is cleanly
+skipped.
+
+Markers:
+    @pytest.mark.integration  — requires a live external service
+    @pytest.mark.slow         — 10-minute wall-time budget
+
+Never logs GCP access tokens, project IDs, or full API response bodies
+in test output.  Uses ``iterations=3`` to keep the
+experiment short and avoid unnecessary API cost.
+"""
+
+import asyncio
+import os
+import textwrap
+from typing import Dict
+
+import pytest
+
+from skydiscover.api import DiscoveryResult
+from skydiscover.extras.external.alphaevolve_backend import run
+
+
+# ---------------------------------------------------------------------------
+# Credential / env-var gating helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_gcp_credentials() -> bool:
+    """Return True if GCP Application Default Credentials are available.
+
+    Uses the same ``google.auth.default()`` probe that the backend itself
+    calls at runtime.  Never inspects or logs credential values.
+    """
+    try:
+        import google.auth
+
+        google.auth.default()
+        return True
+    except Exception:
+        return False
+
+
+def _has_alphaevolve_env_vars() -> bool:
+    """Return True if both required AlphaEvolve env vars are set and non-empty.
+
+    The backend reads ``ALPHAEVOLVE_PROJECT_ID`` and
+    ``ALPHAEVOLVE_ENGINE_ID`` from the environment to resolve the GCP
+    Discovery Engine endpoint.
+    """
+    project_id = os.environ.get("ALPHAEVOLVE_PROJECT_ID", "")
+    engine_id = os.environ.get("ALPHAEVOLVE_ENGINE_ID", "")
+    return bool(project_id) and bool(engine_id)
+
+
+# ---------------------------------------------------------------------------
+# Inline test data constants
+# ---------------------------------------------------------------------------
+
+TRIVIAL_EVALUATOR_SOURCE = textwrap.dedent(
+    """\
+    def evaluate(program_path: str) -> dict:
+        \"\"\"Score based on source-code length to give AlphaEvolve score variance.\"\"\"
+        with open(program_path, "r") as f:
+            source = f.read()
+        # Longer code -> higher score (capped at 1.0).  This gives the server
+        # meaningful score differences across candidates so it can drive evolution.
+        score = min(1.0, len(source) / 200.0)
+        return {"combined_score": score}
+    """
+)
+
+SEED_PROGRAM_SOURCE = textwrap.dedent(
+    """\
+    def solve(x):
+        return x + 1
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+class TestAlphaEvolveIntegration:
+    """Live integration test for the AlphaEvolve external backend."""
+
+    @pytest.mark.integration
+    @pytest.mark.slow
+    @pytest.mark.asyncio
+    async def test_live_lifecycle(self, tmp_path):  # type: ignore[no-untyped-def]
+        """Run the full AlphaEvolve backend lifecycle against the live API.
+
+        The test is cleanly skipped when credentials or env vars are absent.
+        On flaky API errors, it retries once with a 30-second backoff before
+        skipping.
+
+        Uses ``asyncio.wait_for`` with a 600-second (10-minute) timeout in
+        lieu of ``pytest-timeout`` which is not installed.
+        """
+        # -- Gate on credentials and env vars ---------------------------------
+        if not _has_gcp_credentials():
+            pytest.skip("No GCP credentials available")
+        if not _has_alphaevolve_env_vars():
+            pytest.skip(
+                "ALPHAEVOLVE_PROJECT_ID and/or ALPHAEVOLVE_ENGINE_ID not set"
+            )
+
+        # -- Write test artifacts to tmp_path ---------------------------------
+        evaluator = tmp_path / "evaluator.py"
+        evaluator.write_text(TRIVIAL_EVALUATOR_SOURCE)
+
+        seed = tmp_path / "seed.py"
+        seed.write_text(SEED_PROGRAM_SOURCE)
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        # -- Minimal Config object (only needs file_suffix for the backend) ---
+        # The backend reads project_id / engine_id from env vars, so no
+        # alphaevolve config section is required on the Config object.
+        from skydiscover.config import Config
+
+        config = object.__new__(Config)
+        config.file_suffix = ".py"
+        config.language = "python"
+
+        # -- Retry wrapper (one retry + 30 s backoff) -------------------
+        async def _attempt() -> DiscoveryResult:
+            return await run(
+                program_path=str(seed),
+                evaluator_path=str(evaluator),
+                config_obj=config,
+                iterations=3,
+                output_dir=str(output),
+            )
+
+        last_exc = None
+        for attempt in range(2):  # max 2 attempts
+            try:
+                result = await asyncio.wait_for(_attempt(), timeout=600)
+                break
+            except asyncio.TimeoutError:
+                pytest.skip(
+                    "AlphaEvolve API timed out after 600 s"
+                )
+            except Exception as exc:
+                last_exc = exc
+                if attempt == 0:
+                    # First failure — back off and retry once
+                    await asyncio.sleep(30)
+                else:
+                    # Second failure — skip, not hard-fail
+                    pytest.skip(
+                        f"AlphaEvolve API flaky: {last_exc}"
+                    )
+
+        # -- Assertions -----------------------------------------------
+        assert isinstance(result, DiscoveryResult)
+        assert isinstance(result.best_solution, str) and len(result.best_solution) > 0
+        assert isinstance(result.best_score, float) and result.best_score >= 0.0
+        assert isinstance(result.metrics, dict)
+        assert "combined_score" in result.metrics
+        assert result.output_dir == str(output)

--- a/tests/extras/external/test_score_bridging.py
+++ b/tests/extras/external/test_score_bridging.py
@@ -1,0 +1,86 @@
+"""Unit tests for AlphaEvolve score bridging functions."""
+
+import pytest
+
+from skydiscover.extras.external.alphaevolve_backend import (
+    _ae_scores_to_metrics,
+    _metrics_to_ae_scores,
+)
+
+
+class TestMetricsToAeScores:
+    """Tests for _metrics_to_ae_scores (skydiscover metrics -> AE format)."""
+
+    def test_single_metric(self) -> None:
+        result = _metrics_to_ae_scores({"combined_score": 0.85})
+
+        scores_list = result["scores"]["scores"]
+        assert len(scores_list) == 1
+        assert scores_list[0]["metric"] == "combined_score"
+        assert scores_list[0]["score"] == 0.85
+        assert result["insights"] == {}
+
+    def test_multiple_metrics(self) -> None:
+        result = _metrics_to_ae_scores({"accuracy": 0.9, "speed": 0.7})
+
+        scores_list = result["scores"]["scores"]
+        assert len(scores_list) == 2
+        metrics_found = {s["metric"]: s["score"] for s in scores_list}
+        assert metrics_found["accuracy"] == 0.9
+        assert metrics_found["speed"] == 0.7
+
+    def test_filters_non_numeric(self) -> None:
+        result = _metrics_to_ae_scores(
+            {"score": 0.5, "name": "test", "passed": True}
+        )
+
+        scores_list = result["scores"]["scores"]
+        assert len(scores_list) == 1
+        assert scores_list[0]["metric"] == "score"
+        assert scores_list[0]["score"] == 0.5
+
+    def test_empty_metrics(self) -> None:
+        result = _metrics_to_ae_scores({})
+
+        assert result == {"scores": {"scores": []}, "insights": {}}
+
+
+class TestAeScoresToMetrics:
+    """Tests for _ae_scores_to_metrics (AE format -> skydiscover metrics)."""
+
+    def test_extracts_combined_score(self) -> None:
+        evaluation = {
+            "scores": {
+                "scores": [{"metric": "combined_score", "score": 0.9}]
+            }
+        }
+
+        result = _ae_scores_to_metrics(evaluation)
+        assert result["combined_score"] == 0.9
+
+    def test_auto_adds_combined_score_from_first(self) -> None:
+        evaluation = {
+            "scores": {
+                "scores": [{"metric": "accuracy", "score": 0.8}]
+            }
+        }
+
+        result = _ae_scores_to_metrics(evaluation)
+        assert result["accuracy"] == 0.8
+        assert result["combined_score"] == 0.8
+
+    def test_empty_scores(self) -> None:
+        evaluation = {"scores": {"scores": []}}
+
+        result = _ae_scores_to_metrics(evaluation)
+        assert result == {}
+
+    def test_none_score_becomes_zero(self) -> None:
+        evaluation = {
+            "scores": {
+                "scores": [{"metric": "combined_score", "score": None}]
+            }
+        }
+
+        result = _ae_scores_to_metrics(evaluation)
+        assert result["combined_score"] == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,21 @@ wheels = [
 ]
 
 [[package]]
+name = "alpha-evolve"
+version = "0.1.0"
+source = { git = "https://github.com/Google-Cloud-AI/alphaevolve-on-googlecloud.git?branch=main#8693985fa0eebf1a3b8fe2a64b7594e74ddb6557" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "matplotlib" },
+    { name = "nest-asyncio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -673,7 +688,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -751,7 +766,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -857,7 +872,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
@@ -883,11 +898,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "clarabel", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "osqp", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scs", marker = "python_full_version < '3.11'" },
+    { name = "clarabel" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "osqp" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "scs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/7f/2a13e0e7ee76c03bc11aae397572e82d8a8bd23c1c3ac020766f0e15da8e/cvxpy-1.7.5.tar.gz", hash = "sha256:4b512218001c27659e16fc914a2490038635874681032c3c3485ff1099b83f5d", size = 1651490, upload-time = "2025-12-05T03:48:49.127Z" }
 wheels = [
@@ -929,12 +944,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "clarabel", marker = "python_full_version >= '3.11'" },
-    { name = "highspy", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "osqp", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scs", marker = "python_full_version >= '3.11'" },
+    { name = "clarabel" },
+    { name = "highspy" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "osqp" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "scs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/4b/8863001697e08f435dc06a858633dfc27d94fc0a0da882b9bfdebd44d0b3/cvxpy-1.8.1.tar.gz", hash = "sha256:3fbdb1f81be7237c58742b1618bb9f809eeacf6c131705e2540b87ecef9cf402", size = 1752323, upload-time = "2026-02-03T22:04:53.134Z" }
 wheels = [
@@ -1083,7 +1098,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1644,7 +1659,7 @@ name = "highspy"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/17/74553587944f514142618c6d1b76551acf09fb0dd48abe9f4c37fb7d2bb8/highspy-1.13.1.tar.gz", hash = "sha256:7888873501c6ca3e0fa19fee960c8b3cb1c64132c5a9b514903cc7e259b5b0c7", size = 1597930, upload-time = "2026-02-11T16:39:55.185Z" }
 wheels = [
@@ -1911,11 +1926,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -1938,11 +1953,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/40/f85d1feadd8f793fc1bfab726272523ef34b27302b55861ea872ec774019/jax-0.9.0.1.tar.gz", hash = "sha256:e395253449d74354fa813ff9e245acb6e42287431d8a01ff33d92e9ee57d36bd", size = 2534795, upload-time = "2026-02-05T18:47:33.088Z" }
 wheels = [
@@ -1957,9 +1972,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -1998,9 +2013,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/fd/040321b0f4303ec7b558d69488c6130b1697c33d88dab0a0d2ccd2e0817c/jaxlib-0.9.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ff2c550dab210278ed3a3b96454b19108a02e0795625be56dca5a181c9833c9", size = 56092920, upload-time = "2026-02-05T18:46:20.873Z" },
@@ -2744,6 +2759,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2952,7 +2976,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2963,7 +2987,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2990,9 +3014,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -3003,7 +3027,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3248,10 +3272,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3307,9 +3331,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -4169,7 +4193,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/45/bfaaab38545a33a9f06c61211fc3bea2e23e8a8e00fedeb8e57feda722ff/pywavelets-1.8.0.tar.gz", hash = "sha256:f3800245754840adc143cbc29534a1b8fc4b8cff6e9d403326bd52b7bb5c35aa", size = 3935274, upload-time = "2024-12-04T19:54:20.593Z" }
 wheels = [
@@ -4228,7 +4252,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/75/50581633d199812205ea8cdd0f6d52f12a624886b74bf1486335b67f01ff/pywavelets-1.9.0.tar.gz", hash = "sha256:148d12203377772bea452a59211d98649c8ee4a05eff019a9021853a36babdc8", size = 3938340, upload-time = "2025-08-04T16:20:04.978Z" }
 wheels = [
@@ -4556,10 +4580,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -4606,10 +4630,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -4647,7 +4671,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4714,7 +4738,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4901,6 +4925,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
+    { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "tqdm" },
 ]
@@ -4923,6 +4948,7 @@ dev = [
     { name = "requests" },
 ]
 external = [
+    { name = "alpha-evolve" },
     { name = "gepa" },
     { name = "litellm" },
     { name = "openevolve" },
@@ -4973,6 +4999,7 @@ prompt-optimization = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alpha-evolve", marker = "extra == 'external'", git = "https://github.com/Google-Cloud-AI/alphaevolve-on-googlecloud.git?branch=main" },
     { name = "anthropic", marker = "extra == 'frontier-cs'", specifier = ">=0.74.0" },
     { name = "autograd", marker = "extra == 'math'" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=22.0.0" },
@@ -5008,6 +5035,7 @@ requires-dist = [
     { name = "pystemmer", marker = "extra == 'prompt-optimization'", specifier = ">=2.2.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-dotenv", marker = "extra == 'frontier-cs'", specifier = ">=1.2.1" },
     { name = "pywavelets", marker = "extra == 'math'" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -5360,6 +5388,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
## Summary
- Integrates Google's AlphaEvolve EAP SDK as a new external backend (`search_type="alphaevolve"`)
- Adds GCP credential validation, config resolution with env-var overrides, language-aware EVOLVE-BLOCK marker auto-wrapping (Python `#` / C++ `//`), score bridging between skydiscover and AlphaEvolve formats, and evaluator adaptation
- Post-loop check warns when a high fraction of generated programs fail submission (with neutral messaging — could be slow evaluator, auth errors, or rate limits)
- Includes 50 unit tests (config, initial program, score bridging) plus a gated live integration test

## Test plan
- [x] All 50 new unit tests pass (`test_alphaevolve_config`, `test_initial_program`, `test_score_bridging`)
- [x] Full existing test suite (242 tests) passes with zero regressions
- [x] Live integration test against real GCP Discovery Engine API passed (171s)