### PR TITLE
Multiobjective Pareto support for EvoX

### DIFF
--- a/configs/evox.yaml
+++ b/configs/evox.yaml
@@ -34,6 +34,13 @@ search:
   type: "evox"
   database:
     auto_generate_variation_operators: true
+    # Opt-in multiobjective (issue #42). Leave empty for scalar combined_score.
+    # pareto_objectives: ["accuracy", "latency"]
+    # higher_is_better:
+    #   accuracy: true
+    #   latency: false
+    # fitness_key: accuracy
+    # pareto_objectives_weight: 0.4
 
 # Prompt configuration
 prompt:

--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -355,11 +355,23 @@ class EvolveDatabaseConfig(DatabaseConfig):
 
 @dataclass
 class EvoxDatabaseConfig(EvolveDatabaseConfig):
-    """Evox (co-evolution) database config with built-in defaults."""
+    """Evox (co-evolution) database config with built-in defaults.
+
+    Multiobjective fields mirror AdaEvolve (#39 / issue #42): when
+    ``pareto_objectives`` is non-empty, the solution database maintains a
+    Pareto front and uses a scalar proxy only for tie-breaking / search
+    scoring. Leave empty for scalar ``combined_score`` behaviour.
+    """
 
     evaluation_file: Optional[str] = None
     config_path: Optional[str] = None
     auto_generate_variation_operators: bool = True
+
+    # Metric direction / multiobjective (opt-in)
+    higher_is_better: Dict[str, bool] = field(default_factory=dict)
+    fitness_key: Optional[str] = None
+    pareto_objectives: List[str] = field(default_factory=list)
+    pareto_objectives_weight: float = 0.0
 
     _evox_config_dir = Path(__file__).parent / "search" / "evox" / "config"
     _evox_database_dir = Path(__file__).parent / "search" / "evox" / "database"

--- a/skydiscover/context_builder/default/builder.py
+++ b/skydiscover/context_builder/default/builder.py
@@ -254,8 +254,7 @@ class DefaultContextBuilder(ContextBuilder):
 
         if self._is_multiobjective_enabled():
             improvement_areas.append(
-                "Focus on Pareto trade-offs across: "
-                + ", ".join(self._objective_descriptions())
+                "Focus on Pareto trade-offs across: " + ", ".join(self._objective_descriptions())
             )
             for objective in getattr(self._db_config(), "pareto_objectives", None) or []:
                 if objective in metrics and isinstance(metrics[objective], (int, float)):

--- a/skydiscover/context_builder/default/builder.py
+++ b/skydiscover/context_builder/default/builder.py
@@ -228,6 +228,21 @@ class DefaultContextBuilder(ContextBuilder):
 
         return "".join(lines)
 
+    def _db_config(self):
+        return getattr(self.config.search, "database", None)
+
+    def _is_multiobjective_enabled(self) -> bool:
+        return bool(getattr(self._db_config(), "pareto_objectives", None) or [])
+
+    def _objective_descriptions(self) -> List[str]:
+        db_config = self._db_config()
+        higher_is_better = getattr(db_config, "higher_is_better", None) or {}
+        descriptions = []
+        for objective in getattr(db_config, "pareto_objectives", None) or []:
+            direction = "maximize" if higher_is_better.get(objective, True) else "minimize"
+            descriptions.append(f"{objective} ({direction})")
+        return descriptions
+
     def _identify_improvement_areas(
         self,
         current_program: str,
@@ -236,6 +251,15 @@ class DefaultContextBuilder(ContextBuilder):
     ) -> str:
         """Generate bullet points: score trend vs previous attempt, simplification hint."""
         improvement_areas = []
+
+        if self._is_multiobjective_enabled():
+            improvement_areas.append(
+                "Focus on Pareto trade-offs across: "
+                + ", ".join(self._objective_descriptions())
+            )
+            for objective in getattr(self._db_config(), "pareto_objectives", None) or []:
+                if objective in metrics and isinstance(metrics[objective], (int, float)):
+                    improvement_areas.append(f"Current {objective}: {metrics[objective]:.4f}")
 
         current_score = metrics.get("combined_score", 0.0)
         if not isinstance(current_score, (int, float)):
@@ -268,7 +292,7 @@ class DefaultContextBuilder(ContextBuilder):
         threshold = self.context_config.suggest_simplification_after_chars
         if threshold and len(current_program) > threshold:
             improvement_areas.append(
-                f"Consider simplifying - solution length exceeds {threshold} characters"
+                f"Solution is long (>{threshold} chars); consider simplifying while preserving quality"
             )
 
         if not improvement_areas:

--- a/skydiscover/search/base_database.py
+++ b/skydiscover/search/base_database.py
@@ -15,7 +15,8 @@ from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from skydiscover.config import DatabaseConfig
-from skydiscover.utils.metrics import format_metrics, get_score
+from skydiscover.utils.metrics import compute_proxy_score, format_metrics, get_score
+from skydiscover.utils.pareto import nondominated_items, objective_vector
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,10 @@ class ProgramDatabase(ABC):
 
         # Best program tracking
         self.best_program_id: Optional[str] = None
+
+        # Lazy Pareto-front cache (invalidated on add when multiobjective)
+        self._pareto_front_cache: Optional[List[Program]] = None
+        self._pareto_front_cache_valid: bool = False
 
         # Prompt log
         self.prompts_by_program: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None
@@ -207,6 +212,61 @@ class ProgramDatabase(ABC):
     # Best program tracking
     # ------------------------------------------------------------------
 
+    def is_multiobjective_enabled(self) -> bool:
+        """Return True when explicit Pareto objectives are configured."""
+        return bool(getattr(self.config, "pareto_objectives", None) or [])
+
+    def _proxy_score(self, program: Program) -> float:
+        """Scalar proxy for ranking / tie-breaking (shared with AdaEvolve)."""
+        metrics = program.metrics or {}
+        return compute_proxy_score(
+            metrics,
+            fitness_key=getattr(self.config, "fitness_key", None),
+            pareto_objectives=(
+                list(getattr(self.config, "pareto_objectives", []) or [])
+                if self.is_multiobjective_enabled()
+                else None
+            ),
+            higher_is_better=getattr(self.config, "higher_is_better", None) or {},
+        )
+
+    def _invalidate_pareto_cache(self) -> None:
+        self._pareto_front_cache_valid = False
+        self._pareto_front_cache = None
+
+    def get_pareto_front(self) -> List[Program]:
+        """Return the global non-dominated front (lazy-cached).
+
+        When multiobjective is disabled, falls back to ``[best]`` or ``[]``.
+        """
+        if not self.programs:
+            return []
+        if not self.is_multiobjective_enabled():
+            best = self.get_best_program()
+            return [best] if best is not None else []
+
+        if self._pareto_front_cache_valid and self._pareto_front_cache is not None:
+            return list(self._pareto_front_cache)
+
+        programs = list(self.programs.values())
+        objectives = list(getattr(self.config, "pareto_objectives", []) or [])
+        hib = getattr(self.config, "higher_is_better", None) or {}
+        vectors = []
+        eligible = []
+        for program in programs:
+            vec = objective_vector(program.metrics or {}, objectives, hib)
+            if vec is None:
+                continue
+            eligible.append(program)
+            vectors.append(vec)
+
+        front = nondominated_items(eligible, vectors) if eligible else []
+        # Stable tie-break by proxy score for a deterministic representative order.
+        front.sort(key=self._proxy_score, reverse=True)
+        self._pareto_front_cache = front
+        self._pareto_front_cache_valid = True
+        return list(front)
+
     def _is_better(self, program1: Program, program2: Program) -> bool:
         """Determine if program1 has better fitness than program2."""
         if not program1.metrics and not program2.metrics:
@@ -216,10 +276,23 @@ class ProgramDatabase(ABC):
             return True
         if not program1.metrics and program2.metrics:
             return False
+        if self.is_multiobjective_enabled():
+            return self._proxy_score(program1) > self._proxy_score(program2)
         return get_score(program1.metrics) > get_score(program2.metrics)
 
     def _update_best_program(self, program: Program) -> None:
         """Update the best program tracking after a new program is added."""
+        self._invalidate_pareto_cache()
+
+        if self.is_multiobjective_enabled():
+            # Representative best = highest proxy score on the Pareto front.
+            front = self.get_pareto_front()
+            if front:
+                self.best_program_id = front[0].id
+            elif self.best_program_id is None:
+                self.best_program_id = program.id
+            return
+
         if self.best_program_id is None:
             self.best_program_id = program.id
             logger.debug(f"Set initial best program to {program.id}")
@@ -240,6 +313,13 @@ class ProgramDatabase(ABC):
         if not self.programs:
             return None
 
+        if metric is None and self.is_multiobjective_enabled():
+            front = self.get_pareto_front()
+            if front:
+                self.best_program_id = front[0].id
+                return front[0]
+            return None
+
         if metric is None and self.best_program_id:
             if self.best_program_id in self.programs:
                 return self.programs[self.best_program_id]
@@ -253,6 +333,12 @@ class ProgramDatabase(ABC):
             sorted_programs = sorted(
                 [p for p in self.programs.values() if metric in p.metrics],
                 key=lambda p: p.metrics[metric],
+                reverse=True,
+            )
+        elif self.is_multiobjective_enabled():
+            sorted_programs = sorted(
+                self.programs.values(),
+                key=self._proxy_score,
                 reverse=True,
             )
         else:
@@ -280,12 +366,24 @@ class ProgramDatabase(ABC):
                 key=lambda p: p.metrics[metric],
                 reverse=True,
             )
-        else:
-            sorted_programs = sorted(
-                self.programs.values(),
-                key=lambda p: get_score(p.metrics),
+            return sorted_programs[:n]
+
+        if self.is_multiobjective_enabled():
+            # Prefer Pareto members first, then fill with proxy-ranked remainder.
+            front = self.get_pareto_front()
+            front_ids = {p.id for p in front}
+            remainder = sorted(
+                [p for p in self.programs.values() if p.id not in front_ids],
+                key=self._proxy_score,
                 reverse=True,
             )
+            return (front + remainder)[:n]
+
+        sorted_programs = sorted(
+            self.programs.values(),
+            key=lambda p: get_score(p.metrics),
+            reverse=True,
+        )
 
         return sorted_programs[:n]
 

--- a/skydiscover/search/evox/README.md
+++ b/skydiscover/search/evox/README.md
@@ -84,6 +84,19 @@ search:
   type: "evox"
   database:
     auto_generate_variation_operators: true
+    # Opt-in multiobjective (same knobs as AdaEvolve / issue #42):
+    # pareto_objectives: ["accuracy", "latency"]
+    # higher_is_better: {accuracy: true, latency: false}
+    # fitness_key: accuracy
 ```
 
 Ablation flag: `auto_generate_variation_operators` — set to `false` to use default templates for variation operator instead of LLM-generated ones.
+
+### Multiobjective mode
+
+When `pareto_objectives` is configured, the solution database:
+
+- Maintains a lazy-cached global Pareto front
+- Samples parents preferentially from the front
+- Uses `compute_proxy_score` / `fitness_key` only for representative-best and search-window scoring
+- Leaves scalar behaviour unchanged when the list is empty

--- a/skydiscover/search/evox/controller.py
+++ b/skydiscover/search/evox/controller.py
@@ -493,11 +493,13 @@ class CoEvolutionController(DiscoveryController):
         return migrated
 
     def _get_best_score(self) -> float:
-        """Get the current best solution score (combined_score metric)."""
+        """Get the current best solution score (proxy / combined_score)."""
 
         best = self.database.get_best_program()
 
         if best and best.metrics:
+            if getattr(self.database, "is_multiobjective_enabled", lambda: False)():
+                return float(self.database._proxy_score(best))
             score = best.metrics.get("combined_score")
             return float(score) if isinstance(score, (int, float)) else 0.0
         return getattr(self.database, "initial_program_score", None) or 0.0

--- a/skydiscover/search/evox/database/initial_search_strategy.py
+++ b/skydiscover/search/evox/database/initial_search_strategy.py
@@ -16,7 +16,12 @@ class EvolvedProgram(Program):
 
 
 class EvolvedProgramDatabase(ProgramDatabase):
-    """Initial search strategy database."""
+    """Initial search strategy database.
+
+    When ``config.pareto_objectives`` is set, sampling prefers members of the
+    global Pareto front (issue #42) while still mixing in non-front programs
+    for exploration. Scalar mode keeps the original uniform random sample.
+    """
 
     def __init__(self, name: str, config: DatabaseConfig):
         super().__init__(name, config)
@@ -44,19 +49,37 @@ class EvolvedProgramDatabase(ProgramDatabase):
         self, num_context_programs: Optional[int] = 4, **kwargs
     ) -> Tuple[Dict[str, EvolvedProgram], Dict[str, List[EvolvedProgram]]]:
         """
-        Picks a random parent and set of context programs.
+        Picks a parent and set of context programs.
+
+        Multiobjective: parent is drawn from the Pareto front when available;
+        context mixes front members with the broader population.
         """
         candidates = list(self.programs.values())
 
         if len(candidates) == 0:
             raise ValueError("No candidates available for sampling")
 
-        parent = random.choice(candidates)
+        front: List[EvolvedProgram] = []
+        if self.is_multiobjective_enabled():
+            front = [p for p in self.get_pareto_front() if p.id in self.programs]
 
-        sample_size = min(num_context_programs + 1, len(candidates))
-        examples = random.sample(candidates, sample_size)
-
-        examples = [p for p in examples if p.id != parent.id][:num_context_programs]
+        if front:
+            parent = random.choice(front)
+            # Prefer other front members for context, then fill from population.
+            pool = [p for p in front if p.id != parent.id]
+            if len(pool) < (num_context_programs or 0):
+                extras = [p for p in candidates if p.id != parent.id and p not in pool]
+                random.shuffle(extras)
+                pool.extend(extras)
+            examples = pool[:num_context_programs]
+            if len(examples) < (num_context_programs or 0):
+                # Extremely small front — allow duplicates avoidance only.
+                examples = [p for p in candidates if p.id != parent.id][:num_context_programs]
+        else:
+            parent = random.choice(candidates)
+            sample_size = min((num_context_programs or 0) + 1, len(candidates))
+            examples = random.sample(candidates, sample_size)
+            examples = [p for p in examples if p.id != parent.id][:num_context_programs]
 
         parent_dict = {"": parent}
         context_programs_dict = {"": examples}

--- a/skydiscover/utils/pareto.py
+++ b/skydiscover/utils/pareto.py
@@ -1,0 +1,128 @@
+"""Pareto-front helpers shared by multiobjective search modes.
+
+Vectors are assumed to already be in **maximization** space (callers should
+run :func:`skydiscover.utils.metrics.normalize_metric_value` first).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar
+
+T = TypeVar("T")
+
+
+def dominates(vec_a: Sequence[float], vec_b: Sequence[float]) -> bool:
+    """True if ``vec_a`` Pareto-dominates ``vec_b`` (all ≥ and at least one >)."""
+    if len(vec_a) != len(vec_b):
+        raise ValueError(
+            f"Objective vectors must have equal length, got {len(vec_a)} vs {len(vec_b)}"
+        )
+    at_least_one_better = False
+    for a, b in zip(vec_a, vec_b):
+        if a < b:
+            return False
+        if a > b:
+            at_least_one_better = True
+    return at_least_one_better
+
+
+def nondominated_indices(vectors: Sequence[Sequence[float]]) -> List[int]:
+    """Return indices of the non-dominated subset of ``vectors``."""
+    n = len(vectors)
+    front: List[int] = []
+    for i in range(n):
+        dominated = False
+        for j in range(n):
+            if i == j:
+                continue
+            if dominates(vectors[j], vectors[i]):
+                dominated = True
+                break
+        if not dominated:
+            front.append(i)
+    return front
+
+
+def nondominated_items(
+    items: Sequence[T],
+    vectors: Sequence[Sequence[float]],
+) -> List[T]:
+    """Filter ``items`` to the non-dominated front given parallel ``vectors``."""
+    if len(items) != len(vectors):
+        raise ValueError("items and vectors must have the same length")
+    return [items[i] for i in nondominated_indices(vectors)]
+
+
+def nsga2_ranks_and_crowding(
+    vectors: Sequence[Sequence[float]],
+) -> Tuple[Dict[int, int], Dict[int, float]]:
+    """NSGA-II non-dominated ranks + crowding distances keyed by index."""
+    n = len(vectors)
+    if n == 0:
+        return {}, {}
+
+    remaining = set(range(n))
+    ranks: Dict[int, int] = {}
+    layers: List[List[int]] = []
+    rank = 0
+    while remaining:
+        front = []
+        for i in list(remaining):
+            dominated = False
+            for j in remaining:
+                if i == j:
+                    continue
+                if dominates(vectors[j], vectors[i]):
+                    dominated = True
+                    break
+            if not dominated:
+                front.append(i)
+        for i in front:
+            ranks[i] = rank
+            remaining.discard(i)
+        layers.append(front)
+        rank += 1
+
+    crowding: Dict[int, float] = {i: 0.0 for i in range(n)}
+    num_objectives = len(vectors[0]) if vectors else 0
+    for layer in layers:
+        if len(layer) <= 2:
+            for i in layer:
+                crowding[i] = float("inf")
+            continue
+        for m in range(num_objectives):
+            sorted_layer = sorted(layer, key=lambda idx: vectors[idx][m])
+            crowding[sorted_layer[0]] = float("inf")
+            crowding[sorted_layer[-1]] = float("inf")
+            obj_range = vectors[sorted_layer[-1]][m] - vectors[sorted_layer[0]][m]
+            if abs(obj_range) < 1e-10:
+                continue
+            for k in range(1, len(sorted_layer) - 1):
+                crowding[sorted_layer[k]] += (
+                    vectors[sorted_layer[k + 1]][m] - vectors[sorted_layer[k - 1]][m]
+                ) / obj_range
+
+    return ranks, crowding
+
+
+def objective_vector(
+    metrics: dict,
+    objectives: Iterable[str],
+    higher_is_better: Optional[dict] = None,
+) -> Optional[List[float]]:
+    """Build a maximization-space objective vector from a metrics dict.
+
+    Missing / non-numeric objectives become ``-inf`` so incomplete metric
+    vectors cannot dominate fully evaluated ones.
+    """
+    from skydiscover.utils.metrics import normalize_metric_value
+
+    objs = list(objectives)
+    if not objs:
+        return None
+    hib = higher_is_better or {}
+    vector: List[float] = []
+    for objective in objs:
+        normalized = normalize_metric_value(objective, metrics.get(objective), hib)
+        vector.append(normalized if normalized is not None else float("-inf"))
+    return vector

--- a/tests/search/test_evox_multiobjective.py
+++ b/tests/search/test_evox_multiobjective.py
@@ -1,0 +1,119 @@
+"""Tests for EvoX multiobjective support (issue #42)."""
+
+from __future__ import annotations
+
+from skydiscover.config import EvoxDatabaseConfig
+from skydiscover.context_builder.default.builder import DefaultContextBuilder
+from skydiscover.config import Config, SearchConfig
+from skydiscover.search.base_database import Program
+from skydiscover.search.evox.database.initial_search_strategy import EvolvedProgramDatabase
+from skydiscover.utils.pareto import dominates, nondominated_indices
+
+
+def _make_program(program_id: str, **metrics) -> Program:
+    return Program(
+        id=program_id,
+        solution=f"def solve():\n    return '{program_id}'\n",
+        metrics=metrics,
+    )
+
+
+def _pareto_db(**extra) -> EvolvedProgramDatabase:
+    config = EvoxDatabaseConfig(
+        pareto_objectives=extra.pop("pareto_objectives", ["accuracy", "latency"]),
+        higher_is_better=extra.pop(
+            "higher_is_better", {"accuracy": True, "latency": False}
+        ),
+        fitness_key=extra.pop("fitness_key", "accuracy"),
+        pareto_objectives_weight=extra.pop("pareto_objectives_weight", 0.4),
+        **extra,
+    )
+    return EvolvedProgramDatabase("evox", config)
+
+
+def test_dominates_and_front_helpers():
+    assert dominates([1.0, 1.0], [0.5, 0.5])
+    assert not dominates([1.0, 0.0], [0.0, 1.0])
+    assert nondominated_indices([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]) == [0, 1]
+
+
+def test_pareto_front_and_representative_best():
+    db = _pareto_db()
+    high_acc = _make_program("p1", accuracy=0.95, latency=90.0, combined_score=0.5)
+    low_lat = _make_program("p2", accuracy=0.90, latency=10.0, combined_score=0.9)
+    dominated = _make_program("p3", accuracy=0.80, latency=120.0, combined_score=0.99)
+
+    db.add(high_acc)
+    db.add(low_lat)
+    db.add(dominated)
+
+    front_ids = {p.id for p in db.get_pareto_front()}
+    assert front_ids == {"p1", "p2"}
+
+    best = db.get_best_program()
+    assert best is not None
+    assert best.id == "p1"  # fitness_key=accuracy
+
+    top_ids = [p.id for p in db.get_top_programs(3)]
+    assert top_ids[0] in {"p1", "p2"}
+    assert "p3" == top_ids[-1]
+
+
+def test_scalar_mode_unchanged():
+    db = EvolvedProgramDatabase("evox", EvoxDatabaseConfig())
+    worse = _make_program("p1", combined_score=0.1)
+    better = _make_program("p2", combined_score=0.9)
+    db.add(worse)
+    db.add(better)
+    assert db.get_best_program().id == "p2"
+    assert [p.id for p in db.get_pareto_front()] == ["p2"]
+
+
+def test_pareto_cache_rebuilds_after_add():
+    db = _pareto_db()
+    db.add(_make_program("p1", accuracy=0.9, latency=50.0))
+    front_a = db.get_pareto_front()
+    front_b = db.get_pareto_front()
+    assert [p.id for p in front_a] == [p.id for p in front_b]
+    assert db._pareto_front_cache_valid is True
+
+    db.add(_make_program("p2", accuracy=0.95, latency=10.0))
+    # add() invalidates then rebuilds via _update_best_program → get_pareto_front
+    front_c = db.get_pareto_front()
+    assert {p.id for p in front_c} == {"p2"}
+    assert db._pareto_front_cache_valid is True
+
+
+def test_sample_prefers_pareto_parent():
+    db = _pareto_db()
+    db.add(_make_program("p1", accuracy=0.95, latency=90.0))
+    db.add(_make_program("p2", accuracy=0.90, latency=10.0))
+    db.add(_make_program("p3", accuracy=0.50, latency=200.0))
+
+    parents = set()
+    for _ in range(40):
+        parent_dict, _ = db.sample(num_context_programs=1)
+        parents.add(next(iter(parent_dict.values())).id)
+    assert parents <= {"p1", "p2"}
+    assert "p3" not in parents
+
+
+def test_default_context_builder_mentions_objectives():
+    config = Config(
+        search=SearchConfig(
+            type="evox",
+            database=EvoxDatabaseConfig(
+                pareto_objectives=["accuracy", "latency"],
+                higher_is_better={"accuracy": True, "latency": False},
+            ),
+        )
+    )
+    builder = DefaultContextBuilder(config)
+    text = builder._identify_improvement_areas(
+        "code",
+        {"accuracy": 0.9, "latency": 12.0, "combined_score": 0.5},
+        [],
+    )
+    assert "Pareto trade-offs" in text
+    assert "accuracy" in text
+    assert "latency" in text


### PR DESCRIPTION
Ports the AdaEvolve multiobjective surface from #39 / issue #42 over to EvoX so systems tasks can keep accuracy vs latency (etc.) as a front instead of collapsing everything into `combined_score`.

### What changes
- Shared `skydiscover.utils.pareto` helpers (dominance / front / NSGA-II ranks)
- `ProgramDatabase` grows lazy `get_pareto_front()`, proxy-score ranking, and Pareto-aware `get_top_programs` when `pareto_objectives` is set
- `EvoxDatabaseConfig` exposes the same knobs as AdaEvolve (`pareto_objectives`, `higher_is_better`, `fitness_key`, `pareto_objectives_weight`)
- Seed `EvolvedProgramDatabase.sample` prefers front members as parents
- Default / EvoX prompt path mentions configured objectives
- Scalar mode unchanged when the list is empty

### How I tested
- `uv run pytest tests/search/test_evox_multiobjective.py`

Related to #42

Made with [Cursor](https://cursor.com)