### PR TITLE
Add FreeToken provider for on-device models

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,35 @@ Any [LiteLLM](https://docs.litellm.ai/)-compatible model works using `provider/m
 --model gemini/gemini-3-pro-preview                          # Gemini
 --model anthropic/claude-sonnet-4-20250514                   # Anthropic
 --model ollama/llama3 --api-base http://localhost:11434/v1   # Local (Ollama, vLLM, etc.)
+--model freetoken/Qwen3.6-35B-A3B                            # On-device via FreeToken
 ```
+
+**On-device models via [FreeToken](https://github.com/FlashML-org/FreeToken)** run
+fully local with no API key. Serve a model, then use the `freetoken/` prefix. The
+endpoint (`http://127.0.0.1:1919/v1`) and key are filled in for you:
+
+```bash
+# 1. Install FreeToken and start a local OpenAI-compatible server
+uv pip install "freetoken[accel]"
+ft serve --model Qwen3.6-35B-A3B                # listens on 127.0.0.1:1919
+
+# 2. Point any SkyDiscover run at it (no --api-base, no key)
+uv run skydiscover-run initial_program.py evaluator.py \
+  --model freetoken/Qwen3.6-35B-A3B \
+  --search evox \
+  --iterations 100
+```
+
+Or set it in a config file:
+
+```yaml
+llm:
+  models:
+    - name: "freetoken/Qwen3.6-35B-A3B"
+      weight: 1.0
+```
+
+Running the server on a different host or port? Add `--api-base http://<host>:<port>/v1`.
 
 Multi-model pools with weighted sampling are supported in config:
 

--- a/README.md
+++ b/README.md
@@ -351,32 +351,19 @@ Any [LiteLLM](https://docs.litellm.ai/)-compatible model works using `provider/m
 --model freetoken/Qwen3.6-35B-A3B                            # On-device via FreeToken
 ```
 
-**On-device models via [FreeToken](https://github.com/FlashML-org/FreeToken)** run
-fully local with no API key. Serve a model, then use the `freetoken/` prefix. The
-endpoint (`http://127.0.0.1:1919/v1`) and key are filled in for you:
+**On-device via [FreeToken](https://github.com/FlashML-org/FreeToken)** runs fully
+local, no API key. Serve a model, then use the `freetoken/` prefix; the endpoint
+(`http://127.0.0.1:1919/v1`) and key are set for you:
 
 ```bash
-# 1. Install FreeToken and start a local OpenAI-compatible server
 uv pip install "freetoken[accel]"
-ft serve --model Qwen3.6-35B-A3B                # listens on 127.0.0.1:1919
+ft serve --model Qwen3.6-35B-A3B          # OpenAI-compatible server on 127.0.0.1:1919
 
-# 2. Point any SkyDiscover run at it (no --api-base, no key)
 uv run skydiscover-run initial_program.py evaluator.py \
-  --model freetoken/Qwen3.6-35B-A3B \
-  --search evox \
-  --iterations 100
+  --model freetoken/Qwen3.6-35B-A3B --search evox --iterations 100
 ```
 
-Or set it in a config file:
-
-```yaml
-llm:
-  models:
-    - name: "freetoken/Qwen3.6-35B-A3B"
-      weight: 1.0
-```
-
-Running the server on a different host or port? Add `--api-base http://<host>:<port>/v1`.
+Add `--api-base http://<host>:<port>/v1` if the server runs elsewhere.
 
 Multi-model pools with weighted sampling are supported in config:
 

--- a/docs/content/docs/getting-started/configuration.mdx
+++ b/docs/content/docs/getting-started/configuration.mdx
@@ -16,20 +16,19 @@ compatible model works:
 --model freetoken/Qwen3.6-35B-A3B        # On-device via FreeToken
 ```
 
-On-device models via [FreeToken](https://github.com/FlashML-org/FreeToken) run fully
-local with no API key. Serve a model, then use the `freetoken/` prefix. The endpoint
-and key are filled in for you:
+On-device via [FreeToken](https://github.com/FlashML-org/FreeToken) runs fully local,
+no API key. Serve a model, then use the `freetoken/` prefix; the endpoint
+(`http://127.0.0.1:1919/v1`) and key are set for you:
 
 ```bash
 uv pip install "freetoken[accel]"
-ft serve --model Qwen3.6-35B-A3B     # OpenAI-compatible API on 127.0.0.1:1919
+ft serve --model Qwen3.6-35B-A3B          # OpenAI-compatible server on 127.0.0.1:1919
 
 uv run skydiscover-run initial_program.py evaluator.py \
   --model freetoken/Qwen3.6-35B-A3B --search evox --iterations 100
 ```
 
-The prefix defaults `api_base` to `http://127.0.0.1:1919/v1`; pass `--api-base
-http://<host>:<port>/v1` if the server runs elsewhere.
+Add `--api-base http://<host>:<port>/v1` if the server runs elsewhere.
 
 ## Pick an algorithm
 

--- a/docs/content/docs/getting-started/configuration.mdx
+++ b/docs/content/docs/getting-started/configuration.mdx
@@ -13,7 +13,23 @@ compatible model works:
 --model gemini/gemini-3-pro-preview      # Google Gemini
 --model anthropic/claude-sonnet-4-6      # Anthropic
 --model ollama/llama3 --api-base http://localhost:11434/v1  # Local
+--model freetoken/Qwen3.6-35B-A3B        # On-device via FreeToken
 ```
+
+On-device models via [FreeToken](https://github.com/FlashML-org/FreeToken) run fully
+local with no API key. Serve a model, then use the `freetoken/` prefix. The endpoint
+and key are filled in for you:
+
+```bash
+uv pip install "freetoken[accel]"
+ft serve --model Qwen3.6-35B-A3B     # OpenAI-compatible API on 127.0.0.1:1919
+
+uv run skydiscover-run initial_program.py evaluator.py \
+  --model freetoken/Qwen3.6-35B-A3B --search evox --iterations 100
+```
+
+The prefix defaults `api_base` to `http://127.0.0.1:1919/v1`; pass `--api-base
+http://<host>:<port>/v1` if the server runs elsewhere.
 
 ## Pick an algorithm
 

--- a/skydiscover/config.py
+++ b/skydiscover/config.py
@@ -34,7 +34,13 @@ _PROVIDERS: Dict[str, tuple] = {
     "huggingface": (None, ["HF_TOKEN", "HUGGINGFACE_API_KEY"]),
     "ollama": (None, []),
     "vllm": (None, []),
+    "freetoken": ("http://127.0.0.1:1919/v1", []),
 }
+
+# Local OpenAI-compatible servers need no real key, but the OpenAI client still
+# requires a non-empty string, so keyless providers get a harmless placeholder.
+_LOCAL_PROVIDERS = frozenset({"ollama", "vllm", "freetoken"})
+_LOCAL_PLACEHOLDER_KEY = "EMPTY"
 
 # Bare model-name prefixes → provider  (backwards compat for --model gpt-5, etc.)
 _BARE_PREFIX_MAP: Dict[str, str] = {
@@ -78,16 +84,21 @@ def _parse_model_spec(model_str: str) -> tuple:
     return None, model_str, None, []
 
 
-def _resolve_api_key_from_env(env_vars: Optional[List[str]] = None) -> Optional[str]:
+def _resolve_api_key_from_env(
+    env_vars: Optional[List[str]] = None, provider: Optional[str] = None
+) -> Optional[str]:
     """Return the first API key found in *env_vars*.
 
     *env_vars* typically comes from ``_parse_model_spec()``.
-    Only returns a key if it matches the provider's own env vars.
+    Only returns a key if it matches the provider's own env vars. Keyless local
+    providers fall back to a placeholder so the OpenAI client accepts them.
     """
     for var in env_vars or []:
         key = os.environ.get(var)
         if key:
             return key
+    if provider in _LOCAL_PROVIDERS:
+        return _LOCAL_PLACEHOLDER_KEY
     return None
 
 
@@ -201,7 +212,7 @@ class LLMConfig(LLMModelConfig):
                 if provider_base and not (user_set_api_base and provider == "openai"):
                     model.api_base = provider_base
                 if model.api_key is None:
-                    model.api_key = _resolve_api_key_from_env(env_vars)
+                    model.api_key = _resolve_api_key_from_env(env_vars, provider)
                 # Strip provider prefix so the API receives the bare model name
                 if "/" in model.name and provider != "openai":
                     model.name = bare_name
@@ -926,7 +937,7 @@ def apply_overrides(
                     f"Provider '{provider}' requires an explicit api_base.\n"
                     f"Example: model='{spec}', api_base='http://localhost:8000/v1'"
                 )
-            resolved_key = _resolve_api_key_from_env(env_vars)
+            resolved_key = _resolve_api_key_from_env(env_vars, provider)
             models.append(
                 LLMModelConfig(
                     name=model_name,

--- a/tests/config/test_provider_defaults.py
+++ b/tests/config/test_provider_defaults.py
@@ -192,6 +192,44 @@ class TestNonOpenAIProviderRouting:
         assert "anthropic.com" in cfg.models[2].api_base
 
 
+# ── FreeToken / keyless local providers ────────────────────────────
+
+
+class TestFreeTokenProvider:
+    def test_parse_defaults_to_local_endpoint(self):
+        provider, name, api_base, env_vars = _parse_model_spec("freetoken/Qwen3.6-35B-A3B")
+        assert provider == "freetoken"
+        assert name == "Qwen3.6-35B-A3B"
+        assert api_base == "http://127.0.0.1:1919/v1"
+        assert env_vars == []
+
+    def test_keyless_provider_gets_placeholder_key(self):
+        assert _resolve_api_key_from_env([], "freetoken") == "EMPTY"
+        assert _resolve_api_key_from_env([], "ollama") == "EMPTY"
+        assert _resolve_api_key_from_env([], "vllm") == "EMPTY"
+
+    def test_unknown_provider_still_returns_none(self):
+        assert _resolve_api_key_from_env([], None) is None
+        assert _resolve_api_key_from_env([], "mycompany") is None
+
+    def test_config_works_with_no_env_or_flags(self):
+        """freetoken/<model> resolves endpoint, bare name, and placeholder key off-the-shelf."""
+        env = os.environ.copy()
+        env.pop("OPENAI_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            cfg = LLMConfig(models=[LLMModelConfig(name="freetoken/Qwen3.6-35B-A3B")])
+        model = cfg.models[0]
+        assert model.name == "Qwen3.6-35B-A3B"
+        assert model.api_base == "http://127.0.0.1:1919/v1"
+        assert model.api_key == "EMPTY"
+
+    def test_custom_api_base_preserved(self):
+        cfg = LLMConfig(
+            models=[LLMModelConfig(name="freetoken/Qwen3.6-35B-A3B", api_base="http://gpu-box:9000/v1")],
+        )
+        assert cfg.models[0].api_base == "http://gpu-box:9000/v1"
+
+
 # ── MonitorConfig defaults ─────────────────────────────────────────
 
 


### PR DESCRIPTION
Adds first-class support for on-device models served by [FreeToken](https://github.com/FlashML-org/FreeToken), reusing the existing `provider/model` path.

## Usage
```bash
uv pip install "freetoken[accel]"
ft serve --model Qwen3.6-35B-A3B        # OpenAI-compatible API on 127.0.0.1:1919

uv run skydiscover-run initial_program.py evaluator.py \
  --model freetoken/Qwen3.6-35B-A3B --search evox --iterations 100
```
No `--api-base` or API key needed. Override the endpoint with `--api-base http://<host>:<port>/v1` if the server runs elsewhere.

## Changes
- `freetoken` provider registered with the default local endpoint `http://127.0.0.1:1919/v1`.
- Keyless local providers (`ollama`, `vllm`, `freetoken`) get a placeholder key so the OpenAI client accepts them without `OPENAI_API_KEY` set. This also fixes running `ollama`/`vllm` with no key.
- Docs updated in `README.md` and the getting-started configuration page.
- Provider test added in `tests/config/test_provider_defaults.py`.

## Verification
- `black --check` and `isort --check-only` pass on `skydiscover/`.
- All 46 config tests pass (41 existing, 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
